### PR TITLE
Add "global_filter_preference" user custom_field

### DIFF
--- a/app/controllers/filter_tags_controller.rb
+++ b/app/controllers/filter_tags_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ::GlobalFilter
+
+  class FilterTagsController < ::ApplicationController
+    requires_login
+
+    def assign
+      params.require([:user_id, :tag])
+      user = User.find(params[:user_id])
+
+      custom_field = UserCustomField.find_or_create_by(user_id: params[:user_id], name: "global_filter_preference")
+      custom_field.update!(value: params[:tag])
+    end
+  end
+end

--- a/assets/javascripts/discourse/components/global-filter-item.js
+++ b/assets/javascripts/discourse/components/global-filter-item.js
@@ -2,22 +2,52 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import { inject as service } from "@ember/service";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Component.extend({
   router: service(),
   classNames: ["global-filter-item"],
-
-  @action
-  selectFilter(tag) {
-    this._filterTopicsByTag(tag);
-  },
 
   @discourseComputed("siteSettings.global_filters")
   globalFilters() {
     return this.siteSettings.global_filters.split("|");
   },
 
+  @discourseComputed("currentUser.custom_fields.global_filter_preference")
+  highlightActive(tagPreference) {
+    if (this.filter === tagPreference) {
+      return "active";
+    }
+  },
+
+  @action
+  selectFilter(tag) {
+    this._filterTopicsByTag(tag);
+    this._persistTagToServer(tag);
+  },
+
   _filterTopicsByTag(tag) {
     this.router.transitionTo("tag.show", tag);
+  },
+
+  _persistTagToServer(tag) {
+    const user = this.currentUser;
+    if (!user.id || user.custom_fields.global_filter_preference === tag) {
+      return;
+    }
+
+    ajax(`/global_filter/filter_tags/${tag}/assign.json`, {
+      type: "PUT",
+      data: { user_id: user.id },
+    })
+      .then(() => {
+        this._setUserTagPreference(tag);
+      })
+      .catch(popupAjaxError);
+  },
+
+  _setUserTagPreference(tag) {
+    this.set("currentUser.custom_fields.global_filter_preference", tag);
   },
 });

--- a/assets/javascripts/discourse/templates/components/global-filter-item.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter-item.hbs
@@ -1,1 +1,1 @@
-{{d-button action=(action "selectFilter" filter) label=filter class="global-filter-item"}}
+{{d-button action=(action "selectFilter" filter) label=filter class=highlightActive}}

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -4,5 +4,9 @@
 
   .global-filter-item {
     padding: 1rem;
+
+    .active {
+      background-color: var(--tertiary-medium);
+    }
   }
 }

--- a/db/migrate/20220613191208_add_global_filter_preference.rb
+++ b/db/migrate/20220613191208_add_global_filter_preference.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddGlobalFilterPreference < ActiveRecord::Migration[7.0]
+  def change
+    add_index :user_custom_fields, %i[name user_id], name: :idx_user_custom_fields_global_filter_preference,
+                                                     unique: true, where: "name = 'global_filter_preference'"
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,5 +13,49 @@ enabled_site_setting :discourse_global_filter_enabled
 register_asset 'stylesheets/common/global-filter.scss'
 
 after_initialize do
-  PLUGIN_NAME = "discourse-global-filter"
+  require_dependency "topic_query"
+
+  module ::GlobalFilter
+    PLUGIN_NAME ||= "discourse-global-filter"
+    GLOBAL_FILTER_PREFERENCE ||= 'global_filter_preference'
+
+    class Engine < ::Rails::Engine
+      engine_name PLUGIN_NAME
+      isolate_namespace GlobalFilter
+    end
+  end
+
+  [
+    '../app/controllers/filter_tags_controller.rb',
+  ].each { |path| load File.expand_path(path, __FILE__) }
+
+  GlobalFilter::Engine.routes.draw do
+    put '/filter_tags/:tag/assign' => 'filter_tags#assign'
+  end
+
+  Discourse::Application.routes.prepend do
+    mount ::GlobalFilter::Engine, at: '/global_filter'
+  end
+
+  register_editable_user_custom_field(GlobalFilter::GLOBAL_FILTER_PREFERENCE)
+  register_user_custom_field_type(GlobalFilter::GLOBAL_FILTER_PREFERENCE, :string)
+  DiscoursePluginRegistry.serialized_current_user_fields << GlobalFilter::GLOBAL_FILTER_PREFERENCE
+
+  TopicQuery.add_custom_filter(:include_tags) do |results, topic_query|
+    user_custom_fields = topic_query&.user&.custom_fields
+    if user_custom_fields&.has_key?(GlobalFilter::GLOBAL_FILTER_PREFERENCE)
+      tag_id = Tag.find_by(name: user_custom_fields[GlobalFilter::GLOBAL_FILTER_PREFERENCE])&.id
+      return if !tag_id.present?
+
+      results = results.where(<<~SQL, tag_id: tag_id)
+      topics.id IN (
+        SELECT topic_tags.topic_id
+        FROM topic_tags
+        INNER JOIN tags ON tags.id = topic_tags.tag_id
+        WHERE tags.id IN (:tag_id)
+      )
+      SQL
+    end
+    results
+  end
 end


### PR DESCRIPTION
Persist user's global_filter_preference to server and filter topics by (preferred) tag

<img width="848" alt="Screen Shot 2022-06-15 at 10 44 41 AM" src="https://user-images.githubusercontent.com/50783505/173869753-3ef05040-fafc-49cc-827e-9099d44bbda4.png">

we update a users preferred tag each time you select a (different) global filter