### PR TITLE
Update url with global-filter-preference on navigation

### DIFF
--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -1,0 +1,50 @@
+import DiscourseURL, { getCategoryAndTagUrl } from "discourse/lib/url";
+
+export default {
+  name: "global-filter-preference",
+
+  initialize(container) {
+    const siteSettings = container.lookup("site-settings:main");
+    const currentUser = container.lookup("current-user:main");
+    let userGlobalFilterPref =
+      currentUser?.custom_fields?.global_filter_preference;
+
+    if (
+      !siteSettings.discourse_global_filter_enabled ||
+      !userGlobalFilterPref
+    ) {
+      return;
+    }
+
+    const router = container.lookup("router:main");
+    const routesToRedirectOn = siteSettings.top_menu.split("|");
+    routesToRedirectOn.push("/");
+
+    router.on("routeDidChange", () => {
+      if (routesToRedirectOn.includes(router.currentRoute.localName)) {
+        // grab the global_filter_preference in case it was updated
+        userGlobalFilterPref =
+          currentUser.custom_fields.global_filter_preference;
+
+        let url = "";
+
+        url = getCategoryAndTagUrl(
+          this.currentCategory,
+          !this.noSubcategories,
+          userGlobalFilterPref
+        );
+
+        if (router.currentURL !== "/") {
+          url += `/l/${router.currentRoute.localName}`;
+        }
+
+        if (router.currentRoute.queryParams) {
+          const params = router.currentURL.split("?");
+          url += `?${params[1]}`;
+        }
+
+        DiscourseURL.routeTo(url);
+      }
+    });
+  },
+};


### PR DESCRIPTION
I intend on adding tests in a separate PR

### Examples

User selects the <kbd>job-application</kbd> global filter
Redirect to -> `tag/job-application`

User navigates to root url
Redirect to -> `tag/job-application` (saved as global-filter-preference)

User selects <kbd>Unread</kbd>
Redirect to -> `/tag/job-application/l/unread`

User selects <kbd>Tracked</kbd>
Redirect to -> `/tag/job-application/l/latest?f=tracked`