### PR TITLE
Add global-filter css class to body on navigation

### DIFF
--- a/.github/workflows/plugin-linting.yml
+++ b/.github/workflows/plugin-linting.yml
@@ -47,7 +47,6 @@ jobs:
           if [ 0 -lt $(find test -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
             yarn prettier --list-different "test/**/*.{js,es6}"
           fi
-
       - name: Ember template lint
         if: ${{ always() }}
         run: yarn ember-template-lint --no-error-on-unmatched-pattern assets/javascripts

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build_type: ["backend", "frontend-legacy", "frontend"]
+        build_type: ["backend", "frontend"]
 
     steps:
       - uses: actions/checkout@v3
@@ -46,17 +46,14 @@ jobs:
         run: |
           git config --global user.email "ci@ci.invalid"
           git config --global user.name "Discourse CI"
-
       - name: Start redis
         run: |
           redis-server /etc/redis/redis.conf &
-
       - name: Start Postgres
         run: |
           chown -R postgres /var/run/postgresql
           sudo -E -u postgres script/start_test_db.rb
           sudo -u postgres psql -c "CREATE ROLE $PGUSER LOGIN SUPERUSER PASSWORD '$PGPASSWORD';"
-
       - name: Bundler cache
         uses: actions/cache@v3
         with:
@@ -64,7 +61,6 @@ jobs:
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gem-
-
       - name: Setup gems
         run: |
           gem install bundler --conservative -v $(awk '/BUNDLED WITH/ { getline; gsub(/ /,""); print $0 }' Gemfile.lock)
@@ -73,7 +69,6 @@ jobs:
           bundle config --local without development
           bundle install --jobs 4
           bundle clean
-
       - name: Lint English locale
         if: matrix.build_type == 'backend'
         run: bundle exec ruby script/i18n_lint.rb "plugins/${{ github.event.repository.name }}/locales/{client,server}.en.yml"
@@ -90,7 +85,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
       - name: Yarn install
         run: yarn install
 
@@ -102,7 +96,6 @@ jobs:
           key: >-
             ${{ hashFiles('.github/workflows/tests.yml') }}-
             ${{ hashFiles('db/**/*', 'plugins/**/db/**/*') }}-
-
       - name: Restore database from cache
         if: steps.app-cache.outputs.cache-hit == 'true'
         run: psql -f tmp/app-cache/cache.sql postgres
@@ -116,7 +109,6 @@ jobs:
         run: |
           bin/rake db:create
           bin/rake db:migrate
-
       - name: Dump database for cache
         if: steps.app-cache.outputs.cache-hit != 'true'
         run: mkdir -p tmp/app-cache && pg_dumpall > tmp/app-cache/cache.sql
@@ -132,25 +124,18 @@ jobs:
           if [ 0 -lt $(find plugins/${{ github.event.repository.name }}/spec -type f -name "*.rb" 2> /dev/null | wc -l) ]; then
             echo "::set-output name=files_exist::true"
           fi
-
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && steps.check_spec.outputs.files_exist == 'true'
         run: bin/rake plugin:spec[${{ github.event.repository.name }}]
 
-      - name: Check qunit existence
+      - name: Check QUnit existence
         id: check_qunit
         shell: bash
         run: |
           if [ 0 -lt $(find plugins/${{ github.event.repository.name }}/test/javascripts -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
             echo "::set-output name=files_exist::true"
           fi
-
       - name: Plugin QUnit
-        if: matrix.build_type == 'frontend-legacy' && steps.check_qunit.outputs.files_exist == 'true'
-        run: QUNIT_EMBER_CLI=0 bundle exec rake plugin:qunit['${{ github.event.repository.name }}','1200000']
-        timeout-minutes: 10
-
-      - name: Plugin QUnit (Ember CLI)
         if: matrix.build_type == 'frontend' && steps.check_qunit.outputs.files_exist == 'true'
         run: QUNIT_EMBER_CLI=1 bundle exec rake plugin:qunit['${{ github.event.repository.name }}','1200000']
         timeout-minutes: 10

--- a/assets/javascripts/discourse/components/global-filter-item.js
+++ b/assets/javascripts/discourse/components/global-filter-item.js
@@ -1,8 +1,6 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
-import { ajax } from "discourse/lib/ajax";
-import { popupAjaxError } from "discourse/lib/ajax-error";
 import DiscourseURL from "discourse/lib/url";
 
 export default Component.extend({
@@ -17,31 +15,6 @@ export default Component.extend({
 
   @action
   selectFilter(tag) {
-    this._filterTopicsByTag(tag);
-    this._persistTagToServer(tag);
-  },
-
-  _filterTopicsByTag(tag) {
     DiscourseURL.routeTo(`/tag/${tag}`);
-  },
-
-  _persistTagToServer(tag) {
-    const user = this.currentUser;
-    if (!user.id || user.custom_fields.global_filter_preference === tag) {
-      return;
-    }
-
-    ajax(`/global_filter/filter_tags/${tag}/assign.json`, {
-      type: "PUT",
-      data: { user_id: user.id },
-    })
-      .then(() => {
-        this._setUserTagPreference(tag);
-      })
-      .catch(popupAjaxError);
-  },
-
-  _setUserTagPreference(tag) {
-    this.set("currentUser.custom_fields.global_filter_preference", tag);
   },
 });

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -1,4 +1,13 @@
 import { run } from "@ember/runloop";
+import { Promise } from "rsvp";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+const ROUTES_TO_REDIRECT_ON = [
+  "discovery.latest",
+  "discovery.top",
+  "discovery.unread",
+];
 
 export default {
   name: "global-filter-preference",
@@ -6,31 +15,85 @@ export default {
   initialize(container) {
     const siteSettings = container.lookup("site-settings:main");
     const currentUser = container.lookup("current-user:main");
-    const userGlobalFilterPref =
-      currentUser?.custom_fields?.global_filter_preference;
-
-    if (
-      !siteSettings.discourse_global_filter_enabled ||
-      !userGlobalFilterPref
-    ) {
+    if (!siteSettings.discourse_global_filter_enabled || !currentUser) {
       return;
     }
-
     const router = container.lookup("router:main");
-    router.on("routeWillChange", (transition) => {
-      const routesToRedirectOn = siteSettings.top_menu.split("|");
-      const localName = transition.to?.localName;
 
-      if (localName && routesToRedirectOn.includes(localName)) {
-        run(router, function () {
-          return router.replaceWith(
-            `/tag/${userGlobalFilterPref}/l/${localName}`,
-            {
-              queryParams: transition.to.queryParams,
-            }
+    router.on("routeWillChange", (transition) => {
+      const globalFilters = siteSettings.global_filters.split("|");
+      const tag = transition.to?.params?.tag_id;
+      let userGlobalFilterPref =
+        currentUser.custom_fields?.global_filter_preference;
+
+      if (
+        tag &&
+        globalFilters.includes(tag) &&
+        (!userGlobalFilterPref || userGlobalFilterPref !== tag)
+      ) {
+        new Promise((resolve) =>
+          resolve(
+            this._setClientAndServerTagPref(tag, currentUser, globalFilters)
+          )
+        ).then(() => {
+          return this._redirectToFilterPref(
+            transition,
+            router,
+            userGlobalFilterPref
           );
         });
       }
+
+      this._updateBodyFilterClass(userGlobalFilterPref, globalFilters);
+      return this._redirectToFilterPref(
+        transition,
+        router,
+        userGlobalFilterPref
+      );
     });
+  },
+
+  _redirectToFilterPref(transition, router, filterPref) {
+    const routeName = transition.to?.name;
+
+    if (filterPref && routeName && ROUTES_TO_REDIRECT_ON.includes(routeName)) {
+      run(router, function () {
+        return router.replaceWith(
+          `/tag/${filterPref}/l/${transition.to?.localName}`,
+          {
+            queryParams: transition.to.queryParams,
+          }
+        );
+      });
+    }
+  },
+
+  _setClientAndServerTagPref(tag, user, globalFilters) {
+    ajax(`/global_filter/filter_tags/${tag}/assign.json`, {
+      type: "PUT",
+      data: { user_id: user.id },
+    })
+      .then(() => {
+        const filter = this._setClientUserTagPreference(tag, user);
+        this._updateBodyFilterClass(filter, globalFilters);
+      })
+      .catch(popupAjaxError);
+  },
+
+  _setClientUserTagPreference(tag, user) {
+    return user.set("custom_fields.global_filter_preference", tag);
+  },
+
+  _updateBodyFilterClass(filter, globalFilters = []) {
+    globalFilters.filter((arg) => this._addOrRemoveFilterClass(arg, filter));
+  },
+
+  _addOrRemoveFilterClass(filter, globalFilter) {
+    const filterClass = `global-filter-tag-${filter}`;
+    if (filter === globalFilter) {
+      return document.body.classList.add(filterClass);
+    }
+
+    document.body.classList.remove(filterClass);
   },
 };

--- a/assets/javascripts/discourse/templates/components/global-filter-item.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter-item.hbs
@@ -2,4 +2,5 @@
   action=(action "selectFilter" filter)
   translatedLabel=filter
   class=highlightActive
+  id=(concat "global-filter-" filter)
 }}

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -2,92 +2,269 @@ import { click, currentURL, visit } from "@ember/test-helpers";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
-acceptance("Discourse Global Filter - Filter Preference", function (needs) {
-  needs.user({ custom_fields: { global_filter_preference: "support" } });
-  needs.settings({
-    discourse_global_filter_enabled: true,
-    global_filters: "support|feature",
-  });
+acceptance(
+  "Discourse Global Filter - Filter Preference Initializer",
+  function (needs) {
+    needs.user({ custom_fields: { global_filter_preference: "support" } });
+    needs.settings({
+      discourse_global_filter_enabled: true,
+      global_filters: "support|feature",
+    });
 
-  needs.pretender((server, helper) => {
-    server.get("/tag/support/notifications", () =>
-      helper.response({
-        tag_notification: { id: "support", notification_level: 2 },
-      })
-    );
+    needs.pretender((server, helper) => {
+      server.get("/tag/support/l/top.json", () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [],
+            topics: [],
+          },
+        });
+      });
 
-    server.get("/tag/support/l/latest.json", () => {
-      return helper.response({
-        users: [],
-        primary_groups: [],
-        topic_list: {
-          can_create_topic: true,
-          draft: null,
-          draft_key: "new_topic",
-          draft_sequence: 1,
-          per_page: 30,
-          tags: [],
-          topics: [],
-        },
+      server.get("/tag/blog/l/latest.json", () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [],
+            topics: [],
+          },
+        });
       });
     });
 
-    server.get("/tag/support/l/top.json", () => {
-      return helper.response({
-        users: [],
-        primary_groups: [],
-        topic_list: {
-          can_create_topic: true,
-          draft: null,
-          draft_key: "new_topic",
-          draft_sequence: 1,
-          per_page: 30,
-          tags: [],
-          topics: [],
-        },
+    test("redirects to tag when selected", async function (assert) {
+      await visit("/");
+      await click(
+        ".global-filter-container .global-filter-item #global-filter-support"
+      );
+
+      assert.equal(
+        currentURL(),
+        "/tag/support",
+        "it redirects to the right tag"
+      );
+    });
+
+    test("maintains tag filter when redirecting to a filtered topic view", async function (assert) {
+      await visit("/");
+      await click("#navigation-bar .nav-item_top a");
+
+      assert.equal(
+        currentURL(),
+        "/tag/support/l/top",
+        "it redirects to the user's global_filter_preference"
+      );
+    });
+
+    test("maintains tag filter when redirecting to root URL", async function (assert) {
+      await visit("/");
+
+      assert.equal(
+        currentURL(),
+        "/tag/support/l/latest",
+        "it redirects to the user's global_filter_preference"
+      );
+    });
+
+    test("maintains params when redirecting", async function (assert) {
+      await visit("/latest?f=tracked");
+
+      assert.equal(
+        currentURL(),
+        "/tag/support/l/latest?f=tracked",
+        "it redirects to the user's global_filter_preference"
+      );
+    });
+
+    test("adds global-filter css class to body", async function (assert) {
+      await visit("/");
+      assert.ok(
+        document
+          .querySelector("body")
+          .classList.contains("global-filter-tag-support"),
+        "includes users filter preference class on the body"
+      );
+    });
+  }
+);
+
+acceptance(
+  "Discourse Global Filter - Filter Preference Actions",
+  function (needs) {
+    needs.user({ custom_fields: { global_filter_preference: "support" } });
+    needs.settings({
+      discourse_global_filter_enabled: true,
+      global_filters: "support|feature",
+    });
+
+    needs.pretender((server, helper) => {
+      server.get("/tag/support/notifications", () =>
+        helper.response({
+          tag_notification: { id: "support", notification_level: 2 },
+        })
+      );
+
+      server.get("/tag/feature/notifications", () =>
+        helper.response({
+          tag_notification: { id: "feature", notification_level: 2 },
+        })
+      );
+
+      server.get("/tag/blog/notifications", () =>
+        helper.response({
+          tag_notification: { id: "blog", notification_level: 2 },
+        })
+      );
+
+      server.get("/tag/support/l/latest.json", () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [],
+            topics: [],
+          },
+        });
+      });
+
+      server.get("/tag/feature/l/latest.json", () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [],
+            topics: [],
+          },
+        });
+      });
+
+      server.get("/tag/blog/l/latest.json", () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [],
+            topics: [],
+          },
+        });
+      });
+
+      server.get("/tag/support/l/top.json", () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [],
+            topics: [],
+          },
+        });
+      });
+
+      server.put("/global_filter/filter_tags/support/assign.json", () => {
+        return helper.response({ success: true });
+      });
+
+      server.put("/global_filter/filter_tags/feature/assign.json", () => {
+        return helper.response({ success: true });
       });
     });
 
-    server.put("/global_filter/filter_tags/support/assign.json", () => {
-      return helper.response({ success: true });
+    test("redirects to tag when selected", async function (assert) {
+      await visit("/");
+      await click(
+        ".global-filter-container .global-filter-item #global-filter-support"
+      );
+
+      assert.equal(
+        currentURL(),
+        "/tag/support",
+        "it redirects to the right tag"
+      );
     });
-  });
 
-  test("redirects to tag when selected", async function (assert) {
-    await visit("/");
-    await click(".global-filter-container .global-filter-item button");
+    test("maintains tag filter when redirecting to a filtered topic view", async function (assert) {
+      await visit("/");
+      await click("#navigation-bar .nav-item_top a");
 
-    assert.equal(currentURL(), "/tag/support", "it redirects to the right tag");
-  });
+      assert.equal(
+        currentURL(),
+        "/tag/support/l/top",
+        "it redirects to the user's global_filter_preference"
+      );
+    });
 
-  test("maintains tag filter when redirecting to a filtered topic view", async function (assert) {
-    await visit("/");
-    await click("#navigation-bar .nav-item_top a");
+    test("maintains tag filter when redirecting to root URL", async function (assert) {
+      await visit("/");
 
-    assert.equal(
-      currentURL(),
-      "/tag/support/l/top",
-      "it redirects to the user's global_filter_preference"
-    );
-  });
+      assert.equal(
+        currentURL(),
+        "/tag/support/l/latest",
+        "it redirects to the user's global_filter_preference"
+      );
+    });
 
-  test("maintains tag filter when redirecting to root URL", async function (assert) {
-    await visit("/");
+    test("maintains params when redirecting", async function (assert) {
+      await visit("/latest?f=tracked");
 
-    assert.equal(
-      currentURL(),
-      "/tag/support/l/latest",
-      "it redirects to the user's global_filter_preference"
-    );
-  });
+      assert.equal(
+        currentURL(),
+        "/tag/support/l/latest?f=tracked",
+        "it redirects to the user's global_filter_preference"
+      );
+    });
 
-  test("maintains params when redirecting", async function (assert) {
-    await visit("/latest?f=tracked");
+    test("adds global-filter css class to body", async function (assert) {
+      await visit("/");
+      assert.ok(
+        document
+          .querySelector("body")
+          .classList.contains("global-filter-tag-support"),
+        "includes users filter preference class on the body"
+      );
+    });
 
-    assert.equal(
-      currentURL(),
-      "/tag/support/l/latest?f=tracked",
-      "it redirects to the user's global_filter_preference"
-    );
-  });
-});
+    test("doesn't store tag as preference if not included in global_filters", async function (assert) {
+      const currentUser = this.container.lookup("current-user:main");
+      await visit("/tag/blog");
+
+      assert.equal(
+        currentUser.custom_fields.global_filter_preference,
+        "support",
+        "it does not update the users global_filter_preference"
+      );
+    });
+  }
+);

--- a/test/javascripts/components/global-filter-container-test.js
+++ b/test/javascripts/components/global-filter-container-test.js
@@ -5,7 +5,32 @@ import { test } from "qunit";
 acceptance("Discourse Global Filter - Filter Container", function (needs) {
   needs.settings({
     discourse_global_filter_enabled: true,
-    global_filters: "support|feature",
+    global_filters: "support",
+  });
+  needs.user({ custom_fields: { global_filter_preference: "support" } });
+
+  needs.pretender((server, helper) => {
+    server.get("/tag/support/notifications", () =>
+      helper.response({
+        tag_notification: { id: "support", notification_level: 2 },
+      })
+    );
+
+    server.get("/tag/support/l/latest.json", () => {
+      return helper.response({
+        users: [],
+        primary_groups: [],
+        topic_list: {
+          can_create_topic: true,
+          draft: null,
+          draft_key: "new_topic",
+          draft_sequence: 1,
+          per_page: 30,
+          tags: [],
+          topics: [],
+        },
+      });
+    });
   });
 
   test("is present when a tag is included in global_filters", async function (assert) {


### PR DESCRIPTION
Attach a `global-filter-tag-GLOBAL-FILTER-PREF` class to the `<body>` whilst navigating.

eg.  global_filter_preference = `open` --> `<body>` will have a `global-filter-tag-open` class

This class persists on non-tag routes (eg. /topic) and will be updated anytime a new `global_filter_preference` is set.