### PR TITLE
UX: remove active class, tag name formatting

### DIFF
--- a/assets/javascripts/discourse/components/global-filter-item.js
+++ b/assets/javascripts/discourse/components/global-filter-item.js
@@ -1,9 +1,15 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import discourseComputed from "discourse-common/utils/decorators";
 import DiscourseURL from "discourse/lib/url";
 
 export default Component.extend({
   classNames: ["global-filter-item"],
+
+  @discourseComputed("filter")
+  spacedTag(filter) {
+    return filter.replace(/-|_/g, " ");
+  },
 
   @action
   selectFilter(tag) {

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -184,6 +184,10 @@ export default {
     if (tags) {
       tags = tags.filter((tag) => globalFilters.includes(tag));
       tags = tags[0];
+    } else {
+      document.querySelectorAll(".global-filter-item").forEach((filter) => {
+        filter.querySelector("button").classList.remove("active");
+      });
     }
     return tags;
   },

--- a/assets/javascripts/discourse/templates/components/global-filter-item.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter-item.hbs
@@ -1,5 +1,5 @@
 {{d-button
   action=(action "selectFilter" filter)
-  translatedLabel=filter
+  translatedLabel=spacedTag
   id=(concat "global-filter-" filter)
 }}


### PR DESCRIPTION
1. When routed to the home page the `active` class wasn't removed from the buttons
2. Replacing hyphens and underscores in the tag name with a space