### PR TITLE
Hide GTF values from tag-chooser

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/composer-container.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-container.js
@@ -4,6 +4,10 @@ import { inject as service } from "@ember/service";
 export default class GlobalFilterComposerContainer extends Component {
   @service siteSettings;
 
+  canDisplay =
+    this.args.composer.creatingTopic === true &&
+    !this.args.composer.creatingPrivateMessage;
+
   get globalFilters() {
     const filters = this.siteSettings.global_filters;
     if (!filters) {

--- a/assets/javascripts/discourse/components/global-filter/filtered-composer-tags-chooser.js
+++ b/assets/javascripts/discourse/components/global-filter/filtered-composer-tags-chooser.js
@@ -1,0 +1,8 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+export default class GlobalFilterFilteredComposerTagsChooser extends Component {
+  @service siteSettings;
+
+  hiddenValues = this.siteSettings.global_filters.split("|");
+}

--- a/assets/javascripts/discourse/components/global-filter/filtered-tags-chooser.js
+++ b/assets/javascripts/discourse/components/global-filter/filtered-tags-chooser.js
@@ -1,0 +1,3 @@
+import templateOnly from "@ember/component/template-only";
+
+export default templateOnly();

--- a/assets/javascripts/discourse/connectors/after-title-and-category/filtered-tags-chooser.hbs
+++ b/assets/javascripts/discourse/connectors/after-title-and-category/filtered-tags-chooser.hbs
@@ -1,0 +1,11 @@
+<GlobalFilter::FilteredComposerTagsChooser
+  @tagValidation={{tagValidation}}
+  @canEditTags={{canEditTags}}
+  @value={{model.tags}}
+  @onChange={{action (mut model.tags)}}
+  @options={{hash
+    disabled=disabled
+    categoryId=model.categoryId
+    minimum=model.minimumRequiredTags
+  }}
+/>

--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/filtered-tags-chooser.hbs
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/filtered-tags-chooser.hbs
@@ -1,8 +1,7 @@
 <GlobalFilter::FilteredTagsChooser
-  @mainTag={{this.parentView.mainTag}}
-  @currentCategory={{this.parentView.currentCategory}}
-  @options={{this.parentView.options}}
-  @additionalTags={{this.parentView.additionalTags}}
-  @noSubcategories={{this.parentView.noSubcategories}}
-  @tagId={{this.parentView.tagId}}
+  @currentCategory={{this.currentCategory}}
+  @options={{hash categoryId=this.currentCategory.id}}
+  @additionalTags={{this.additionalTags}}
+  @noSubcategories={{this.noSubcategories}}
+  @tagId={{this.tagId}}
 />

--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/filtered-tags-chooser.hbs
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/filtered-tags-chooser.hbs
@@ -1,0 +1,8 @@
+<GlobalFilter::FilteredTagsChooser
+  @mainTag={{this.parentView.mainTag}}
+  @currentCategory={{this.parentView.currentCategory}}
+  @options={{this.parentView.options}}
+  @additionalTags={{this.parentView.additionalTags}}
+  @noSubcategories={{this.parentView.noSubcategories}}
+  @tagId={{this.parentView.tagId}}
+/>

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -46,7 +46,7 @@ export default {
         let tagCombination;
 
         if (additionalTags && tag) {
-          tagCombination = additionalTags + `\${tag}`;
+          tagCombination = tag + "/" + additionalTags;
         }
 
         if (currentUser) {

--- a/assets/javascripts/discourse/templates/components/global-filter/composer-container.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/composer-container.hbs
@@ -1,10 +1,12 @@
-<div class="global-filter-composer-container">
-  {{#if this.globalFilters}}
-    {{#each this.globalFilters as |filter|}}
-      <GlobalFilter::ComposerItem
-        @filter={{filter}}
-        @composer={{@composer}}
-      />
-    {{/each}}
-  {{/if}}
-</div>
+{{#if this.canDisplay}}
+  <div class="global-filter-composer-container">
+    {{#if this.globalFilters}}
+      {{#each this.globalFilters as |filter|}}
+        <GlobalFilter::ComposerItem
+          @filter={{filter}}
+          @composer={{@composer}}
+        />
+      {{/each}}
+    {{/if}}
+  </div>
+{{/if}}

--- a/assets/javascripts/discourse/templates/components/global-filter/composer-container.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/composer-container.hbs
@@ -1,12 +1,7 @@
 {{#if this.canDisplay}}
   <div class="global-filter-composer-container">
-    {{#if this.globalFilters}}
-      {{#each this.globalFilters as |filter|}}
-        <GlobalFilter::ComposerItem
-          @filter={{filter}}
-          @composer={{@composer}}
-        />
-      {{/each}}
-    {{/if}}
+    {{#each this.globalFilters as |filter|}}
+      <GlobalFilter::ComposerItem @filter={{filter}} @composer={{@composer}} />
+    {{/each}}
   </div>
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/global-filter/filtered-composer-tags-chooser.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/filtered-composer-tags-chooser.hbs
@@ -1,0 +1,9 @@
+{{#if @canEditTags}}
+  <MiniTagChooser
+    @value={{@value}}
+    @onChange={{@onChange}}
+    @options={{@options}}
+    @hiddenValues={{this.hiddenValues}}
+  />
+  <PopupInputTip @validation={{@tagValidation}} />
+{{/if}}

--- a/assets/javascripts/discourse/templates/components/global-filter/filtered-composer-tags-chooser.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/filtered-composer-tags-chooser.hbs
@@ -2,8 +2,7 @@
   <MiniTagChooser
     @value={{@value}}
     @onChange={{@onChange}}
-    @options={{@options}}
-    @hiddenFromPreview={{this.hiddenValues}}
+    @options={{hash @options hiddenValues=this.hiddenValues}}
   />
   <PopupInputTip @validation={{@tagValidation}} />
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/global-filter/filtered-composer-tags-chooser.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/filtered-composer-tags-chooser.hbs
@@ -3,7 +3,7 @@
     @value={{@value}}
     @onChange={{@onChange}}
     @options={{@options}}
-    @hiddenValues={{this.hiddenValues}}
+    @hiddenFromPreview={{this.hiddenValues}}
   />
   <PopupInputTip @validation={{@tagValidation}} />
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/global-filter/filtered-tags-chooser.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/filtered-tags-chooser.hbs
@@ -1,0 +1,18 @@
+{{#if @additionalTags}}
+  <li>
+    <TagsIntersectionChooser
+      @currentCategory={{@currentCategory}}
+      @mainTag={{null}}
+      @additionalTags={{@additionalTags}}
+      @options={{@options}}
+    />
+  </li>
+{{else}}
+  <li>
+    <TagDrop
+      @currentCategory={{@category}}
+      @noSubcategories={{@noSubcategories}}
+      @tagId={{null}}
+    />
+  </li>
+{{/if}}

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -19,3 +19,10 @@
     margin-right: 1rem;
   }
 }
+
+.navigation-container {
+  // hide default tag chooser
+  li:nth-child(2) {
+    display: none;
+  }
+}

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -26,3 +26,14 @@
     display: none;
   }
 }
+
+.composer-fields .title-and-category details.mini-tag-chooser:first-of-type {
+  // hide default composer tag chooser
+  display: none;
+}
+
+.composer-fields .title-and-category details.mini-tag-chooser {
+  // because we are dynamically showing and hiding elements the max-width
+  // was not being calculated properly. `Unset` sets the value to expected width
+  max-width: unset !important;
+}

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -20,11 +20,9 @@
   }
 }
 
-.navigation-container {
+.navigation-container ol > li > details.tags-intersection-chooser {
   // hide default tag chooser
-  li:nth-child(2) {
-    display: none;
-  }
+  display: none;
 }
 
 .composer-fields .title-and-category details.mini-tag-chooser:first-of-type {

--- a/plugin.rb
+++ b/plugin.rb
@@ -41,4 +41,3 @@ after_initialize do
   register_user_custom_field_type(GlobalFilter::GLOBAL_FILTER_PREFERENCE, :string)
   DiscoursePluginRegistry.serialized_current_user_fields << GlobalFilter::GLOBAL_FILTER_PREFERENCE
 end
-

--- a/plugin.rb
+++ b/plugin.rb
@@ -41,3 +41,4 @@ after_initialize do
   register_user_custom_field_type(GlobalFilter::GLOBAL_FILTER_PREFERENCE, :string)
   DiscoursePluginRegistry.serialized_current_user_fields << GlobalFilter::GLOBAL_FILTER_PREFERENCE
 end
+


### PR DESCRIPTION
- [x] add custom tag drop chooser
> viewing /tag/GLOBAL_FILTER
<img width="483" alt="Screen Shot 2022-08-18 at 12 50 22 PM" src="https://user-images.githubusercontent.com/50783505/185461425-12e0d165-36fd-44d5-a55a-8dd680fffc03.png">

- [x] add custom tag intersection chooser
> viewing /tags/intersection/GLOBAL_FILTER/cloud
<img width="718" alt="Screen Shot 2022-08-18 at 1 06 55 PM" src="https://user-images.githubusercontent.com/50783505/185464258-9fef33c3-0aa3-4033-b569-d905c0afeb7a.png">

- [x] add custom tag drop chooser for **composer**
> see that we can create a topic with a global-filter-tag, and not have that value show up in the tag-chooser. Even though the attached GFT does not show up in the select-kit preview, it does persist on topic creation.
<img width="782" alt="Screen Shot 2022-08-18 at 4 56 56 PM" src="https://user-images.githubusercontent.com/50783505/185502353-8b3ab4a9-f8b0-4216-8160-4edd79f7115c.png">

- [x] dont display global filter items in composer if composing PM



