### PR TITLE
DEV: too many containers with the same class name

### DIFF
--- a/assets/javascripts/discourse/components/global-filter-container.js
+++ b/assets/javascripts/discourse/components/global-filter-container.js
@@ -2,7 +2,7 @@ import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
-  classNames: ["global-filter-container"],
+  tagName: "",
 
   @discourseComputed("siteSettings.global_filters")
   globalFilters(filters) {

--- a/assets/javascripts/discourse/templates/components/global-filter-container.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter-container.hbs
@@ -1,6 +1,6 @@
 {{#if globalFilters}}
   {{plugin-outlet name="above-global-filter-container"}}
-  <div class="global-filter-container">
+  <div class="global-filter-button-container">
     {{#each globalFilters as |filter|}}
       {{global-filter-item filter=filter id=(concat "global-filter-" filter)}}
     {{/each}}

--- a/assets/javascripts/discourse/templates/components/global-filter-item.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter-item.hbs
@@ -1,6 +1,7 @@
 {{d-button
   action=(action "selectFilter" filter)
   translatedLabel=spacedTag
+  class="global-filter-button"
 }}
 
 {{plugin-outlet name="below-global-filter-item"  args=(hash filter=filter)}}


### PR DESCRIPTION
There were 3 containers with the class `global-filter-container` which was making CSS a bit difficult. This removes one, renames one, and leaves one original parent. 