### PR TITLE
FIX: Keep global filter button active class

### DIFF
--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -169,14 +169,14 @@ export default {
       const filterBodyClass = `global-filter-tag-${item}`;
       if (item === tags) {
         document
-          .getElementById(`global-filter-${item}`)
+          .querySelector(`#global-filter-${item} > .btn`)
           .classList.add("active");
         document.body.classList.add(filterBodyClass);
         return;
       }
 
       document
-        .getElementById(`global-filter-${item}`)
+        .querySelector(`#global-filter-${item} > .btn`)
         .classList.remove("active");
       document.body.classList.remove(filterBodyClass);
     });
@@ -187,10 +187,6 @@ export default {
     if (tags) {
       tags = tags.filter((tag) => globalFilters.includes(tag));
       tags = tags[0];
-    } else {
-      document.querySelectorAll(".global-filter-item").forEach((filter) => {
-        filter.querySelector("button").classList.remove("active");
-      });
     }
     return tags;
   },

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -1,11 +1,11 @@
-.global-filter-container {
+.global-filter-button-container {
   display: flex;
   justify-content: center;
 
   .global-filter-item {
     padding: 1rem;
 
-    .active {
+    .btn.active {
       background-color: var(--tertiary-medium);
     }
   }

--- a/test/javascripts/components/global-filter-item-test.js
+++ b/test/javascripts/components/global-filter-item-test.js
@@ -14,30 +14,32 @@ acceptance("Discourse Global Filter - Filter Item", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    server.get("/tag/support/notifications", () =>
-      helper.response({
-        tag_notification: { id: "support", notification_level: 2 },
-      })
-    );
-
-    server.get("/tag/support/l/latest.json", () => {
-      return helper.response({
-        users: [],
-        primary_groups: [],
-        topic_list: {
-          can_create_topic: true,
-          draft: null,
-          draft_key: "new_topic",
-          draft_sequence: 1,
-          per_page: 30,
-          tags: [],
-          topics: [],
-        },
+    ["support", "feature"].forEach((tag) => {
+      server.get(`/tag/${tag}/notifications`, () => {
+        return helper.response({
+          tag_notification: { id: tag, notification_level: 2 },
+        });
       });
-    });
 
-    server.put("/global_filter/filter_tags/support/assign.json", () => {
-      return helper.response({ success: true });
+      server.get(`/tag/${tag}/l/latest.json`, () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [],
+            topics: [],
+          },
+        });
+      });
+
+      server.put(`/global_filter/filter_tags/${tag}/assign.json`, () => {
+        return helper.response({ success: true });
+      });
     });
   });
 
@@ -52,10 +54,14 @@ acceptance("Discourse Global Filter - Filter Item", function (needs) {
 
   test("adds active class to filter when selected", async function (assert) {
     await visit("/");
-    await click(".global-filter-container .global-filter-item button");
+    await click(
+      ".global-filter-container #global-filter-feature .global-filter-button"
+    );
 
     assert.ok(
-      exists(".global-filter-container .global-filter-item.active"),
+      exists(
+        ".global-filter-container #global-filter-feature .global-filter-button.active"
+      ),
       "item is active"
     );
   });

--- a/test/javascripts/components/global-filter/composer-item-test.js
+++ b/test/javascripts/components/global-filter/composer-item-test.js
@@ -15,30 +15,32 @@ acceptance("Discourse Global Filter - Composer Item", function (needs) {
   needs.site({ can_tag_topics: true });
 
   needs.pretender((server, helper) => {
-    server.get("/tag/support/notifications", () =>
-      helper.response({
-        tag_notification: { id: "support", notification_level: 2 },
-      })
-    );
-
-    server.get("/tag/support/l/latest.json", () => {
-      return helper.response({
-        users: [],
-        primary_groups: [],
-        topic_list: {
-          can_create_topic: true,
-          draft: null,
-          draft_key: "new_topic",
-          draft_sequence: 1,
-          per_page: 30,
-          tags: [],
-          topics: [],
-        },
+    ["support", "feature"].forEach((tag) => {
+      server.get(`/tag/${tag}/notifications`, () => {
+        return helper.response({
+          tag_notification: { id: tag, notification_level: 2 },
+        });
       });
-    });
 
-    server.put("/global_filter/filter_tags/support/assign.json", () => {
-      return helper.response({ success: true });
+      server.get(`/tag/${tag}/l/latest.json`, () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [],
+            topics: [],
+          },
+        });
+      });
+
+      server.put(`/global_filter/filter_tags/${tag}/assign.json`, () => {
+        return helper.response({ success: true });
+      });
     });
   });
 


### PR DESCRIPTION
This is a partial revert of https://github.com/discourse/discourse-global-filter/pull/12. We do need to keep the active class, even if the view is the homepage because the homepage content is going to be filtered by the default global filter. cc @awesomerobot 