### PR TITLE
UX: Minor adjustments to composer checkboxes

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/composer-item.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-item.js
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 
 export default class GlobalFilterComposerItem extends Component {
   checked = this.args.composer.tags?.includes(this.args.filter) ? true : false;
+  spacedTag = this.args.filter.replace(/-|_/g, " ");
 
   @action
   toggleTag() {

--- a/assets/javascripts/discourse/templates/components/global-filter/composer-item.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/composer-item.hbs
@@ -1,12 +1,9 @@
-<div class="global-filter-composer-item">
-  <div class={{concat "global-filter-composer-tag-" @filter}}>
-    <label>
-      <Input
-        @type="checkbox"
-        @checked={{this.checked}}
-        {{on "click" (action "toggleTag")}}
-      />
-      {{@filter}}
-    </label>
-  </div>
-</div>
+<label class={{concat "global-filter-composer-item global-filter-composer-tag-" @filter}}>
+  <Input
+    @type="checkbox"
+    @checked={{this.checked}}
+    {{on "click" (action "toggleTag")}}
+  />
+  <span class="pre-label"></span>
+  <span class="tag-label">{{this.spacedTag}}</span>
+</label>


### PR DESCRIPTION
- Displays labels without - or _ 
- Simplifies HTML a bit and adds an empty `.pre-label` element which makes it easier to add icons in a theme