### PR TITLE
Replace composer category options when selecting a new filter-item

### DIFF
--- a/app/controllers/filter_tags_controller.rb
+++ b/app/controllers/filter_tags_controller.rb
@@ -10,7 +10,16 @@ class GlobalFilter::FilterTagsController < ::ApplicationController
     custom_field.update!(value: params[:tag])
   end
 
-  def categories_for_global_filter
+  def categories_for_current_filter
     render_serialized(CategoryList.new(guardian), CategoryListSerializer, root: false)
+  end
+
+  def categories_for_filter_tags
+    render_serialized(
+      CategoryList.new(guardian),
+      CategoryListSerializer,
+      root: false,
+      tags: params[:tags]
+    )
   end
 end

--- a/app/models/filter_tag.rb
+++ b/app/models/filter_tag.rb
@@ -9,7 +9,6 @@ class GlobalFilter::FilterTag < ::ActiveRecord::Base
 
   def self.categories_for_tags(tags, scope)
     filter_tags = self.where(name: tags)
-    filter_tags_category_ids = []
     filter_tags_category_ids = filter_tags&.pluck(:category_ids).flat_map do |c|
       c.present? ? c.split("|") : Category.secured(scope).pluck(:id)
     end

--- a/app/models/filter_tag.rb
+++ b/app/models/filter_tag.rb
@@ -7,9 +7,13 @@ class GlobalFilter::FilterTag < ::ActiveRecord::Base
     :category_stats, # TODO(2023-04-01): remove
   ]
 
-  def self.categories_for_tag(tag, scope)
-    filter_tag = self.find_by(name: tag)
-    return [] if !filter_tag&.category_ids&.present?
-    Category.secured(scope).where(id: filter_tag.category_ids.split("|")).to_a
+  def self.categories_for_tags(tags, scope)
+    filter_tags = self.where(name: tags)
+    filter_tags_category_ids = []
+    filter_tags_category_ids = filter_tags&.pluck(:category_ids).flat_map do |c| 
+      c.present? ? c.split("|") : Category.secured(scope).pluck(:id)
+    end
+
+    Category.secured(scope).where(id: filter_tags_category_ids).to_a
   end
 end

--- a/app/models/filter_tag.rb
+++ b/app/models/filter_tag.rb
@@ -10,7 +10,7 @@ class GlobalFilter::FilterTag < ::ActiveRecord::Base
   def self.categories_for_tags(tags, scope)
     filter_tags = self.where(name: tags)
     filter_tags_category_ids = []
-    filter_tags_category_ids = filter_tags&.pluck(:category_ids).flat_map do |c| 
+    filter_tags_category_ids = filter_tags&.pluck(:category_ids).flat_map do |c|
       c.present? ? c.split("|") : Category.secured(scope).pluck(:id)
     end
 

--- a/assets/javascripts/discourse/components/global-filter/composer-container.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-container.js
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
-import { makeArray } from "discourse-common/lib/helpers";
 
 export default class GlobalFilterComposerContainer extends Component {
   @service siteSettings;

--- a/assets/javascripts/discourse/components/global-filter/composer-container.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-container.js
@@ -18,19 +18,4 @@ export default class GlobalFilterComposerContainer extends Component {
     }
     return filters.split("|");
   }
-
-  constructor() {
-    super(...arguments);
-
-    if (this.tagParam) {
-      const composer = this.args.composer;
-      if (composer.tags) {
-        if (composer.tags.includes(this.tagParam)) {
-          composer.tags.push(this.tagParam);
-        }
-      } else {
-        this.args.composer.set("tags", makeArray(this.tagParam));
-      }
-    }
-  }
 }

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -44,7 +44,7 @@ export default {
       // set the custom category options per global filter
       if (routeName === "discovery.categories") {
         ajax(
-          "/global_filter/filter_tags/categories_for_global_filter.json"
+          "/global_filter/filter_tags/categories_for_current_filter.json"
         ).then((model) => {
           categoryDropdown = model.categories;
         });

--- a/lib/category_list_serializer_extension.rb
+++ b/lib/category_list_serializer_extension.rb
@@ -3,7 +3,7 @@
 module GlobalFilter::CategoryListSerializerExtension
 
   def categories
-    filtered_categories = GlobalFilter::FilterTag.categories_for_tag(filter_tag, scope)
-    filtered_categories.any? ? filtered_categories : object.categories
+    tags = options[:tags] || filter_tag
+    GlobalFilter::FilterTag.categories_for_tags(tags, scope)
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -38,7 +38,8 @@ after_initialize do
 
   GlobalFilter::Engine.routes.draw do
     put '/filter_tags/:tag/assign' => 'filter_tags#assign'
-    get '/filter_tags/categories_for_global_filter' => 'filter_tags#categories_for_global_filter'
+    get '/filter_tags/categories_for_current_filter' => 'filter_tags#categories_for_current_filter'
+    get '/filter_tags/categories_for_filter_tags' => 'filter_tags#categories_for_filter_tags'
   end
 
   Discourse::Application.routes.prepend do

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -89,7 +89,7 @@ acceptance(
       });
 
       server.get(
-        "/global_filter/filter_tags/categories_for_global_filter.json",
+        "/global_filter/filter_tags/categories_for_current_filter.json",
         () => {
           return helper.response({ success: true });
         }

--- a/test/javascripts/components/global-filter/composer-item-test.js
+++ b/test/javascripts/components/global-filter/composer-item-test.js
@@ -16,6 +16,13 @@ acceptance("Discourse Global Filter - Composer Item", function (needs) {
 
   needs.pretender((server, helper) => {
     ["support", "feature"].forEach((tag) => {
+      server.get(
+        `/global_filter/filter_tags/categories_for_filter_tags.json`,
+        () => {
+          return helper.response({ success: true });
+        }
+      );
+
       server.get(`/tag/${tag}/notifications`, () => {
         return helper.response({
           tag_notification: { id: tag, notification_level: 2 },
@@ -67,9 +74,10 @@ acceptance("Discourse Global Filter - Composer Item", function (needs) {
 
   test("toggling filter items removes/adds correct tags", async function (assert) {
     await visit("/");
-    await click("#create-topic");
-
     await settled();
+    await click("#create-topic");
+    await settled();
+
     assert.strictEqual(
       query(".global-filter-composer-tag-support input").checked,
       true,
@@ -77,8 +85,10 @@ acceptance("Discourse Global Filter - Composer Item", function (needs) {
     );
     // uncheck support filter
     await click(".global-filter-composer-tag-support input");
+    await settled();
     // check feature filter
     await click(".global-filter-composer-tag-feature input");
+    await settled();
 
     let composer = this.owner.lookup("controller:composer");
     assert.ok(


### PR DESCRIPTION
This gives the ability to "hot reload" the composer category-dropdown options with the filtered categories, per GFT. 

- In the case multiple are selected, we combine the list of categories in the options.
- In the case no GFT is selected we keep the category options of the **last previously selected** GFT