### PR TITLE
Fix category rendering

### DIFF
--- a/app/models/filter_tag.rb
+++ b/app/models/filter_tag.rb
@@ -13,6 +13,6 @@ class GlobalFilter::FilterTag < ::ActiveRecord::Base
       c.present? ? c.split("|") : Category.secured(scope).pluck(:id)
     end
 
-    Category.secured(scope).where(id: filter_tags_category_ids).to_a
+    Category.secured(scope).where(id: filter_tags_category_ids)
   end
 end

--- a/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
@@ -23,7 +23,7 @@ export default class extends Controller {
     });
 
     const data = {
-      category_ids: category_ids,
+      category_ids,
     };
 
     return ajax(

--- a/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
@@ -6,7 +6,25 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 export default class extends Controller {
   @action
   setCategoryIdsForTag(filterTag, categories) {
-    const data = { category_ids: categories.map((c) => c.id) };
+    let category_ids = [];
+
+    categories.map((c) => {
+      category_ids.push(c.id);
+
+      // if category has parent, include parent
+      if (c.parent_category_id) {
+        category_ids.push(c.parent_category_id);
+
+        // check if category is subsubcategory
+        if (c.parentCategory.parent_category_id) {
+          category_ids.push(c.parentCategory.parent_category_id);
+        }
+      }
+    });
+
+    const data = {
+      category_ids: category_ids,
+    };
 
     return ajax(
       `/admin/plugins/filter_tags/${filterTag.name}/set_category_ids_for_tag.json`,

--- a/lib/categories_controller_extension.rb
+++ b/lib/categories_controller_extension.rb
@@ -2,7 +2,7 @@
 
 module GlobalFilter::CategoriesControllerExtension
 
-  def index 
+  def index
     discourse_expires_in 1.minute
 
     @description = SiteSetting.site_description

--- a/lib/categories_controller_extension.rb
+++ b/lib/categories_controller_extension.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module GlobalFilter::CategoriesControllerExtension
+
+  def index 
+    discourse_expires_in 1.minute
+
+    @description = SiteSetting.site_description
+
+    parent_category = Category.find_by_slug(params[:parent_category_id]) || Category.find_by(id: params[:parent_category_id].to_i)
+
+    include_subcategories = SiteSetting.desktop_category_page_style == "subcategories_with_featured_topics" ||
+      params[:include_subcategories] == "true"
+
+    category_options = {
+      is_homepage: current_homepage == "categories",
+      parent_category_id: params[:parent_category_id],
+      include_topics: include_topics(parent_category),
+      include_subcategories: include_subcategories,
+      tag: params[:tag]
+    }
+
+    @category_list = CategoryList.new(guardian, category_options)
+
+    if category_options[:is_homepage] && SiteSetting.short_site_description.present?
+      @title = "#{SiteSetting.title} - #{SiteSetting.short_site_description}"
+    elsif !category_options[:is_homepage]
+      @title = "#{I18n.t('js.filters.categories.title')} - #{SiteSetting.title}"
+    end
+
+    respond_to do |format|
+      format.html do
+        style = SiteSetting.desktop_category_page_style
+        topic_options = {
+          per_page: CategoriesController.topics_per_page,
+          no_definitions: true,
+        }
+
+        if style == "categories_and_latest_topics_created_date"
+          topic_options[:order] = 'created'
+          @topic_list = TopicQuery.new(current_user, topic_options).list_latest
+          @topic_list.more_topics_url = url_for(public_send("latest_path", sort: :created))
+        elsif style == "categories_and_latest_topics"
+          @topic_list = TopicQuery.new(current_user, topic_options).list_latest
+          @topic_list.more_topics_url = url_for(public_send("latest_path"))
+        elsif style == "categories_and_top_topics"
+          @topic_list = TopicQuery.new(current_user, topic_options).list_top_for(SiteSetting.top_page_default_timeframe.to_sym)
+          @topic_list.more_topics_url = url_for(public_send("top_path"))
+        end
+
+        if @topic_list.present? && @topic_list.topics.present?
+          store_preloaded(
+            @topic_list.preload_key,
+            MultiJson.dump(TopicListSerializer.new(@topic_list, scope: guardian))
+          )
+        end
+
+        render
+      end
+
+      format.json { render_serialized(@category_list, CategoryListSerializer) }
+    end
+  end
+end

--- a/lib/category_detailed_serializer_extension.rb
+++ b/lib/category_detailed_serializer_extension.rb
@@ -28,4 +28,10 @@ module GlobalFilter::CategoryDetailedSerializerExtension
   def total_count_for_category_per(time)
     object.global_filter_tags_category_stats[filter_tag]&.fetch(time, 0) || 0
   end
+
+  def subcategory_list
+    filter_tag_ids = GlobalFilter::FilterTag.categories_for_tags(filter_tag, scope).pluck(:id)
+    filtered_categories = object.subcategory_list.present? ? object.subcategory_list.filter { |c| filter_tag_ids.include?(c.id) } : []
+    filtered_categories
+  end
 end

--- a/lib/category_list_serializer_extension.rb
+++ b/lib/category_list_serializer_extension.rb
@@ -4,6 +4,8 @@ module GlobalFilter::CategoryListSerializerExtension
 
   def categories
     tags = options[:tags] || filter_tag
-    GlobalFilter::FilterTag.categories_for_tags(tags, scope)
+    filter_tag_ids = GlobalFilter::FilterTag.categories_for_tags(tags, scope).pluck(:id)
+    filtered_categories = object.categories.filter { |c| filter_tag_ids.include?(c.id) }
+    filtered_categories
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -34,6 +34,8 @@ after_initialize do
     '../jobs/scheduled/update_category_stats.rb',
     '../lib/category_list_serializer_extension.rb',
     '../lib/category_detailed_serializer_extension.rb',
+    '../lib/categories_controller_extension.rb',
+
   ].each { |path| load File.expand_path(path, __FILE__) }
 
   GlobalFilter::Engine.routes.draw do
@@ -59,6 +61,7 @@ after_initialize do
   reloadable_patch do
     CategoryListSerializer.class_eval { prepend GlobalFilter::CategoryListSerializerExtension }
     CategoryDetailedSerializer.class_eval { prepend GlobalFilter::CategoryDetailedSerializerExtension }
+    CategoriesController.class_eval { prepend GlobalFilter::CategoriesControllerExtension }
   end
 
   add_to_serializer(:site, :filter_tags_total_topic_count) do


### PR DESCRIPTION
- Removes caching of category_list on categories#index as it would then require us to reload the page to get filtered results.
- When choosing a category in the admin UI, if the category is a child, include its parent. If it is nested multiple times, include the parent's parent.
- Only display specified categories for a GFT. Before we had children of a category being displayed unintentionally.
- Fix duplicate category displays.