### PR TITLE
Fix admin ui styles / category display

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
@@ -7,21 +7,20 @@ export default class extends Controller {
   @action
   setCategoryIdsForTag(filterTag, categories) {
     let categoryIds = [];
-    let categoriesAndParents = [];
+    let categoriesAndParents = new Set(categories);
 
-    categoriesAndParents.push(categories);
     categories.map((c) => {
       categoryIds.push(c.id);
 
       // if category has parent, include parent
       if (c.parent_category_id) {
         categoryIds.push(c.parent_category_id);
-        categoriesAndParents.push(c.parentCategory);
+        categoriesAndParents.add(c.parentCategory);
 
         // check if category is subsubcategory
         if (c.parentCategory.parent_category_id) {
           categoryIds.push(c.parentCategory.parent_category_id);
-          categoriesAndParents.push(c.parentCategory.parentCategory);
+          categoriesAndParents.add(c.parentCategory.parentCategory);
         }
       }
     });
@@ -38,7 +37,7 @@ export default class extends Controller {
       }
     )
       .then(() => {
-        const uniqCategories = Array.from(new Set(categoriesAndParents.flat()));
+        const uniqCategories = Array.from(categoriesAndParents);
         filterTag.set("categories", uniqCategories);
       })
       .catch(popupAjaxError);

--- a/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
@@ -6,24 +6,28 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 export default class extends Controller {
   @action
   setCategoryIdsForTag(filterTag, categories) {
-    let category_ids = [];
+    let categoryIds = [];
+    let categoriesAndParents = [];
 
+    categoriesAndParents.push(categories);
     categories.map((c) => {
-      category_ids.push(c.id);
+      categoryIds.push(c.id);
 
       // if category has parent, include parent
       if (c.parent_category_id) {
-        category_ids.push(c.parent_category_id);
+        categoryIds.push(c.parent_category_id);
+        categoriesAndParents.push(c.parentCategory);
 
         // check if category is subsubcategory
         if (c.parentCategory.parent_category_id) {
-          category_ids.push(c.parentCategory.parent_category_id);
+          categoryIds.push(c.parentCategory.parent_category_id);
+          categoriesAndParents.push(c.parentCategory.parentCategory);
         }
       }
     });
 
     const data = {
-      category_ids,
+      category_ids: categoryIds,
     };
 
     return ajax(
@@ -34,7 +38,9 @@ export default class extends Controller {
       }
     )
       .then(() => {
-        filterTag.set("categories", categories);
+        console.log(categoriesAndParents);
+        const uniqCategories = Array.from(new Set(categoriesAndParents.flat()));
+        filterTag.set("categories", uniqCategories);
       })
       .catch(popupAjaxError);
   }

--- a/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-filter-tag.js
@@ -38,7 +38,6 @@ export default class extends Controller {
       }
     )
       .then(() => {
-        console.log(categoriesAndParents);
         const uniqCategories = Array.from(new Set(categoriesAndParents.flat()));
         filterTag.set("categories", uniqCategories);
       })

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -44,13 +44,12 @@ ol.category-breadcrumb > li:not(.filtered-tags-chooser) {
 .filter-tag-admin-pane {
   .filter-tag-name {
     float: left;
-    width: 15%;
+    width: 200px;
     margin-right: 12px;
   }
 
   .filter-tag-category-chooser {
-    float: left;
-    width: 80%;
+    width: 75%;
     padding-right: 20px;
     margin-bottom: 15px;
   }


### PR DESCRIPTION
When choosing categories in the admin UI, the selected list would not update in real time if a category had a parent included behind the scenes. This is fixed in this pr. 

Fix bad admin ui on small screens.