### PR TITLE
Filter category and subcategory dropdowns by GFT

### DIFF
--- a/assets/javascripts/discourse/initializers/filtered-categories-for-global-filter.js
+++ b/assets/javascripts/discourse/initializers/filtered-categories-for-global-filter.js
@@ -13,6 +13,7 @@ export default {
           pluginId: PLUGIN_ID,
           queryParams: ["tag"],
         });
+
         api.modifyClass("route:discovery/categories", {
           pluginId: PLUGIN_ID,
 

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -47,6 +47,7 @@ export default {
           "/global_filter/filter_tags/categories_for_current_filter.json"
         ).then((model) => {
           categoryDropdown = model.categories;
+          subcategoryDropdown = model.subcategories;
         });
       }
 
@@ -219,8 +220,24 @@ export default {
 };
 
 let categoryDropdown = [];
+let subcategoryDropdown = [];
 function setFilteredCategoriesForGlobalFilter(api) {
-  api.modifySelectKit("category-drop").appendContent(() => {
-    return categoryDropdown;
+  api.modifySelectKit("category-drop").replaceContent((component) => {
+    const componentParentClasslist = document.getElementById(
+      component.elementId
+    )?.parentElement?.classList;
+    if (componentParentClasslist.contains("gft-parent-categories-picker")) {
+      return categoryDropdown;
+    }
+
+    if (componentParentClasslist.contains("gft-child-categories-picker")) {
+      const filteredChildren = component.content.filter((c) => {
+        const categoriesByName = subcategoryDropdown.map(
+          (item) => item["name"]
+        );
+        return categoriesByName.includes(c.name);
+      });
+      return filteredChildren;
+    }
   });
 }

--- a/assets/javascripts/discourse/initializers/set-category-drop-options.js
+++ b/assets/javascripts/discourse/initializers/set-category-drop-options.js
@@ -1,0 +1,69 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { ajax } from "discourse/lib/ajax";
+
+const PLUGIN_ID = "discourse-global-filter-category-drop-options";
+
+export default {
+  name: "set-category-drop-options",
+
+  initialize(container) {
+    const siteSettings = container.lookup("service:site-settings");
+    if (siteSettings.discourse_global_filter_enabled) {
+      withPluginApi("1.3.0", (api) => {
+        api.modifyClass("controller:discovery/categories", {
+          pluginId: PLUGIN_ID,
+
+          init() {
+            this._super(...arguments);
+            setCategoryDropOptionsPerGlobalFilter(api);
+          },
+        });
+
+        api.modifyClass("controller:tag-show", {
+          pluginId: PLUGIN_ID,
+
+          init() {
+            this._super(...arguments);
+            setCategoryDropOptionsPerGlobalFilter(api);
+          },
+        });
+      });
+    }
+  },
+};
+
+function setCategoryDropOptionsPerGlobalFilter(api) {
+  let categoriesAndSubcategories = {};
+
+  ajax("/global_filter/filter_tags/categories_for_current_filter.json").then(
+    (model) => {
+      categoriesAndSubcategories = {
+        categories: model.categories,
+        subcategories: model.subcategories,
+      };
+
+      api.modifySelectKit("category-drop").replaceContent((categoryDrop) => {
+        const categoryDropParentClasslist = document.getElementById(
+          categoryDrop.elementId
+        ).parentElement.classList;
+
+        if (
+          categoryDropParentClasslist.contains("gft-parent-categories-drop")
+        ) {
+          return categoriesAndSubcategories.categories;
+        }
+
+        if (categoryDropParentClasslist.contains("gft-subcategories-drop")) {
+          const filteredSubcategories = categoryDrop.content.filter((c) => {
+            const categoriesByName =
+              categoriesAndSubcategories.subcategories.map(
+                (item) => item["name"]
+              );
+            return categoriesByName.includes(c.name);
+          });
+          return filteredSubcategories;
+        }
+      });
+    }
+  );
+}

--- a/assets/javascripts/discourse/templates/components/global-filter/filtered-tags-chooser.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/filtered-tags-chooser.hbs
@@ -4,8 +4,8 @@
       class="filtered-category-drop
         {{if
           breadcrumb.isSubcategory
-          'gft-child-categories-picker'
-          'gft-parent-categories-picker'
+          "gft-subcategories-drop"
+          "gft-parent-categories-drop"
         }}"
     >
       <CategoryDrop

--- a/assets/javascripts/discourse/templates/components/global-filter/filtered-tags-chooser.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/filtered-tags-chooser.hbs
@@ -1,9 +1,16 @@
 {{#each @categoryBreadcrumbs as |breadcrumb|}}
   {{#if breadcrumb.hasOptions}}
-    <li class="filtered-category-drop">
+    <li
+      class="filtered-category-drop
+        {{if
+          breadcrumb.isSubcategory
+          'gft-child-categories-picker'
+          'gft-parent-categories-picker'
+        }}"
+    >
       <CategoryDrop
         @category={{breadcrumb.category}}
-        @categories={{null}}
+        @categories={{breadcrumb.options}}
         @tagId={{@tagId}}
         @editingCategory={{@editingCategory}}
         @editingCategoryTab={{@editingCategoryTab}}

--- a/plugin.rb
+++ b/plugin.rb
@@ -78,6 +78,10 @@ after_initialize do
     object.instance_variable_get("@options")&.dig(:tag) || scope.user&.custom_fields&.dig('global_filter_preference') || GlobalFilter::FilterTag.first.name
   end
 
+  add_to_serializer(:category_list, :subcategories) do
+    GlobalFilter::FilterTag.categories_for_tags(filter_tag, scope).filter(&:parent_category_id)
+  end
+
   DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
     if name === :global_filters
       old_values = old_value.split("|")

--- a/test/javascripts/components/global-filter-container-test.js
+++ b/test/javascripts/components/global-filter-container-test.js
@@ -17,6 +17,11 @@ acceptance("Discourse Global Filter - Filter Container", function (needs) {
       })
     );
 
+    server.get(
+      "/global_filter/filter_tags/categories_for_current_filter.json",
+      () => helper.response({ categories: [], subcategories: [] })
+    );
+
     server.get("/tag/support/l/latest.json", () => {
       return helper.response({
         users: [],

--- a/test/javascripts/components/global-filter-item-test.js
+++ b/test/javascripts/components/global-filter-item-test.js
@@ -33,6 +33,11 @@ acceptance("Discourse Global Filter - Filter Item", function (needs) {
       });
     });
 
+    server.get(
+      "/global_filter/filter_tags/categories_for_current_filter.json",
+      () => helper.response({ categories: [], subcategories: [] })
+    );
+
     server.get("/tag/support/notifications", () =>
       helper.response({
         tag_notification: { id: "support", notification_level: 2 },

--- a/test/javascripts/components/global-filter/filtered-tags-chooser-test.js
+++ b/test/javascripts/components/global-filter/filtered-tags-chooser-test.js
@@ -27,6 +27,11 @@ acceptance("Discourse Global Filter - Filtered Tags Chooser", function (needs) {
         },
       });
     });
+
+    server.get(
+      "/global_filter/filter_tags/categories_for_current_filter.json",
+      () => helper.response({ categories: [], subcategories: [] })
+    );
   });
 
   test("hides the selected global filter tag from the tag-drop chooser", async function (assert) {


### PR DESCRIPTION
Category dropdown options (categories) were not being filtered properly and we would display the same list of options for both the category and subcategory dropdowns.

Move the logic required to set the content of category & subcategory dropdown from `discourse/initializers/global-filter-preference.js` to its own initializer. This gets us a few things:
- Scopes category dropdown manipulations to intended dropdowns
- Removes extra (unnecessary) ajax calls on all routes
- Cleans up the `global-filter-preference` initializer