### PR TITLE
DEV: Add global filter to `site` service

### DIFF
--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -193,11 +193,13 @@ export default {
 
     globalFilters.forEach((item) => {
       const filterBodyClass = `global-filter-tag-${item}`;
+      const site = container.lookup("service:site");
       if (item === tags) {
         document
           .querySelector(`#global-filter-${item} > a`)
           .classList.add("active");
         document.body.classList.add(filterBodyClass);
+        site.globalFilter = item;
         return;
       }
 


### PR DESCRIPTION
This PR adds the current global filter as a property in the site service.