### PR TITLE
DEV: Make `spacedTag` a `@tracked` property for easy override

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/filter-item.js
+++ b/assets/javascripts/discourse/components/global-filter/filter-item.js
@@ -1,11 +1,12 @@
 import Component from "@glimmer/component";
 import { defaultHomepage } from "discourse/lib/utilities";
 import { inject as service } from "@ember/service";
+import { tracked } from "@glimmer/tracking";
 
 export default class GlobalFilterFilterItem extends Component {
   @service site;
 
-  spacedTag = this.args.filter.replace(/-|_/g, " ");
+  @tracked spacedTag = this.args.filter.replace(/-|_/g, " ");
   totalFilterTagCount =
     this.site.filter_tags_total_topic_count[this.args.filter];
 


### PR DESCRIPTION
This PR makes the filter dropdown's trigger button's label a `@tracked` property so that it can easily be overridden by themes seeking custom labelling.