### PR TITLE
FIX: Assign correct global filter when in a docs context

### DIFF
--- a/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
+++ b/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
@@ -67,12 +67,13 @@ export default {
     // and docs query parameters
     let tags =
       router.currentRoute?.parent?.attributes?.tags ||
-      router.currentRoute?.queryParams?.tags.split("|") ||
+      router.currentRoute?.queryParams?.tags?.split("|") ||
       null;
     if (tags) {
       tags = tags.filter((tag) => globalFilters.includes(tag));
       tags = tags[0];
     }
+
     return tags;
   },
 };

--- a/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
+++ b/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
@@ -36,7 +36,7 @@ export default {
       tags =
         router.currentRoute?.params?.tag_id ||
         router.currentRoute?.queryParams?.tag ||
-        this._firstGlobalFilterFromParent(router, globalFilters);
+        this._findGlobalFilterMatch(router, globalFilters);
     }
 
     if (!tags) {
@@ -62,8 +62,13 @@ export default {
     });
   },
 
-  _firstGlobalFilterFromParent(router, globalFilters) {
-    let tags = router.currentRoute?.parent?.attributes?.tags || null;
+  _findGlobalFilterMatch(router, globalFilters) {
+    // handles parent route attributes
+    // and docs query parameters
+    let tags =
+      router.currentRoute?.parent?.attributes?.tags ||
+      router.currentRoute?.queryParams?.tags.split("|") ||
+      null;
     if (tags) {
       tags = tags.filter((tag) => globalFilters.includes(tag));
       tags = tags[0];

--- a/test/javascripts/acceptance/global-filter-context-test.js
+++ b/test/javascripts/acceptance/global-filter-context-test.js
@@ -1,0 +1,51 @@
+import { visit } from "@ember/test-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+
+acceptance("Discourse Global Filter - Context", function (needs) {
+  needs.user({ custom_fields: { global_filter_preference: "support" } });
+  needs.site({ filter_tags_total_topic_count: 0 });
+  needs.settings({
+    discourse_global_filter_enabled: true,
+    global_filters: "support|feature",
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/tag/support/notifications", () =>
+      helper.response({
+        tag_notification: { id: "support", notification_level: 2 },
+      })
+    );
+
+    server.get("/tag/support/l/latest.json", () => {
+      return helper.response({
+        users: [],
+        primary_groups: [],
+        topic_list: {
+          can_create_topic: true,
+          draft: null,
+          draft_key: "new_topic",
+          draft_sequence: 1,
+          per_page: 30,
+          tags: [],
+          topics: [],
+        },
+      });
+    });
+
+    server.get(
+      "/global_filter/filter_tags/categories_for_current_filter.json",
+      () => {
+        return helper.response({ success: true });
+      }
+    );
+  });
+
+  test("sets global filter from a 'tags' query param", async function (assert) {
+    await visit("/latest?tags=support");
+    assert.ok(
+      document.body.classList.contains("global-filter-tag-support"),
+      "it contains the right body class"
+    );
+  });
+});

--- a/test/javascripts/components/global-filter/composer-item-test.js
+++ b/test/javascripts/components/global-filter/composer-item-test.js
@@ -1,4 +1,4 @@
-import { click, settled, visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import {
   acceptance,
   query,
@@ -81,21 +81,16 @@ acceptance("Discourse Global Filter - Composer Item", function (needs) {
 
   test("toggling filter items removes/adds correct tags", async function (assert) {
     await visit("/");
-    await settled();
     await click("#create-topic");
-    await settled();
 
     assert.strictEqual(
       query(".global-filter-composer-tag-support input").checked,
       true,
       "support filter is checked by default"
     );
-    // uncheck support filter
+    // switch filter
     await click(".global-filter-composer-tag-support input");
-    await settled();
-    // check feature filter
     await click(".global-filter-composer-tag-feature input");
-    await settled();
 
     let composer = this.owner.lookup("controller:composer");
     assert.ok(
@@ -103,5 +98,9 @@ acceptance("Discourse Global Filter - Composer Item", function (needs) {
       ["feature"],
       "expected filter is present"
     );
+
+    // reset
+    await click(".global-filter-composer-tag-feature input");
+    await click(".global-filter-composer-tag-support input");
   });
 });


### PR DESCRIPTION
The docs parameter is the plural "tags" so we need a special case here for it. (The PR also fixes a flakey composer test.) 