### PR TITLE
REFACTOR: Use a getter for a composer item property

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/composer-container.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-container.js
@@ -12,14 +12,6 @@ export default class GlobalFilterComposerContainer extends Component {
     this.args.composer.creatingTopic === true &&
     !this.args.composer.creatingPrivateMessage;
 
-  get globalFilters() {
-    const filters = this.siteSettings.global_filters;
-    if (!filters) {
-      return false;
-    }
-    return filters.split("|");
-  }
-
   constructor() {
     super(...arguments);
 
@@ -50,5 +42,14 @@ export default class GlobalFilterComposerContainer extends Component {
           });
       });
     });
+  }
+
+  get globalFilters() {
+    const filters = this.siteSettings.global_filters;
+    if (!filters) {
+      return false;
+    }
+
+    return filters.split("|");
   }
 }

--- a/assets/javascripts/discourse/components/global-filter/composer-item.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-item.js
@@ -5,12 +5,9 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 
 export default class GlobalFilterComposerItem extends Component {
   spacedTag = this.args.filter.replace(/-|_/g, " ");
-  checked;
 
-  constructor() {
-    super(...arguments);
-
-    this.checked = this.args.composer.tags?.includes(
+  get checked() {
+    return this.args.composer.tags?.includes(
       this.args.filter || this.args.tagParam
     )
       ? true

--- a/assets/javascripts/discourse/components/global-filter/composer-item.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-item.js
@@ -14,6 +14,10 @@ export default class GlobalFilterComposerItem extends Component {
       : false;
   }
 
+  set checked(value) {
+    return value;
+  }
+
   @action
   toggleTag() {
     if (this.args.composer.tags.includes(this.args.filter)) {

--- a/assets/javascripts/discourse/components/global-filter/composer-item.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-item.js
@@ -9,9 +9,7 @@ export default class GlobalFilterComposerItem extends Component {
   get checked() {
     return this.args.composer.tags?.includes(
       this.args.filter || this.args.tagParam
-    )
-      ? true
-      : false;
+    );
   }
 
   set checked(value) {


### PR DESCRIPTION
It's more "the Ember way" and makes it a tiny bit easier to override if/when needed.

This also fixes a linting issue in composer-container.js