### PR TITLE
DEV: Two small composer refactors

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/composer-item.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-item.js
@@ -24,7 +24,7 @@ export default class GlobalFilterComposerItem extends Component {
   }
 
   get checked() {
-    return this.args.composer.tags?.includes(
+    return this.args.selectedTags?.includes(
       this.args.filter || this.args.tagParam
     );
   }
@@ -35,16 +35,16 @@ export default class GlobalFilterComposerItem extends Component {
 
   @action
   toggleTag() {
-    if (this.args.composer.tags.includes(this.args.filter)) {
-      const filterIndex = this.args.composer.tags.indexOf(this.args.filter);
-      this.args.composer.tags.splice(filterIndex, 1);
+    if (this.args.selectedTags.includes(this.args.filter)) {
+      const filterIndex = this.args.selectedTags.indexOf(this.args.filter);
+      this.args.selectedTags.splice(filterIndex, 1);
     } else {
-      this.args.composer.tags.push(this.args.filter);
+      this.args.selectedTags.push(this.args.filter);
     }
 
     withPluginApi("1.3.0", (api) => {
       ajax(`/global_filter/filter_tags/categories_for_filter_tags.json`, {
-        data: { tags: this.args.composer.tags },
+        data: { tags: this.args.selectedTags },
       }).then((model) => {
         api
           .modifySelectKit("category-chooser")

--- a/assets/javascripts/discourse/components/global-filter/filtered-composer-tags-chooser.js
+++ b/assets/javascripts/discourse/components/global-filter/filtered-composer-tags-chooser.js
@@ -4,5 +4,7 @@ import { inject as service } from "@ember/service";
 export default class GlobalFilterFilteredComposerTagsChooser extends Component {
   @service siteSettings;
 
-  hiddenValues = this.siteSettings.global_filters.split("|");
+  get hiddenValues() {
+    return this.siteSettings.global_filters.split("|");
+  }
 }

--- a/assets/javascripts/discourse/templates/components/global-filter/composer-container.hbs
+++ b/assets/javascripts/discourse/templates/components/global-filter/composer-container.hbs
@@ -3,7 +3,7 @@
     {{#each this.globalFilters as |filter|}}
       <GlobalFilter::ComposerItem
         @filter={{filter}}
-        @composer={{@composer}}
+        @selectedTags={{@composer.tags}}
         @checked={{this.checked}}
         @tagParam={{this.tagParam}}
       />


### PR DESCRIPTION
1. Pass only tags to `ComposerItem`, it's the only property used there.
2. Use getter for `hiddenValues`, makes it easier to override in theme.