### PR TITLE
DEV: Serialize posts per week data

### DIFF
--- a/jobs/scheduled/update_category_stats.rb
+++ b/jobs/scheduled/update_category_stats.rb
@@ -26,8 +26,15 @@ module Jobs
             .where(tags: tag_id)
             .visible
 
+          posts = Post.joins(:topic)
+            .where(topics: category_and_subcategory_topics)
+            .where("topics.visible = true")
+            .where("posts.deleted_at IS NULL")
+            .where("posts.user_deleted = false")
+
           posts_count = category_and_subcategory_topics.pluck(:posts_count).sum
-          counts = { topic_count: category_and_subcategory_topics.count, posts_count: posts_count }
+          posts_week = posts.created_since(1.week.ago).count
+          counts = { topic_count: category_and_subcategory_topics.count, posts_count: posts_count, posts_week: posts_week }
           category_stats_for_filter = category_stats_for_filter.deep_merge(counts)
 
           category_topic_totals = {

--- a/lib/category_detailed_serializer_extension.rb
+++ b/lib/category_detailed_serializer_extension.rb
@@ -25,6 +25,10 @@ module GlobalFilter::CategoryDetailedSerializerExtension
     total_count_for_category_per('topics_year')
   end
 
+  def posts_week
+    total_count_for_category_per('posts_week')
+  end
+
   def total_count_for_category_per(time)
     object.global_filter_tags_category_stats[filter_tag]&.fetch(time, 0) || 0
   end

--- a/lib/category_detailed_serializer_extension.rb
+++ b/lib/category_detailed_serializer_extension.rb
@@ -25,10 +25,6 @@ module GlobalFilter::CategoryDetailedSerializerExtension
     total_count_for_category_per('topics_year')
   end
 
-  def posts_week
-    total_count_for_category_per('posts_week')
-  end
-
   def total_count_for_category_per(time)
     object.global_filter_tags_category_stats[filter_tag]&.fetch(time, 0) || 0
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -75,6 +75,10 @@ after_initialize do
     scope.user&.custom_fields&.dig('global_filter_preference') || scope.request.params[:tag] || GlobalFilter::FilterTag.first.name
   end
 
+  add_to_serializer(:category_detailed, :posts_week) do
+    object.global_filter_tags_category_stats[filter_tag]&.fetch("posts_week", 0) || 0
+  end
+
   add_to_serializer(:category_list, :filter_tag) do
     object.instance_variable_get("@options")&.dig(:tag) || scope.user&.custom_fields&.dig('global_filter_preference') || scope.request.params[:tag] || GlobalFilter::FilterTag.first.name
   end


### PR DESCRIPTION
This PR adds `posts_week` data for categories and subcategories with global filters.