### PR TITLE
UX: Tag topic count should be comma separated

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/filter-item.js
+++ b/assets/javascripts/discourse/components/global-filter/filter-item.js
@@ -5,10 +5,17 @@ import { tracked } from "@glimmer/tracking";
 
 export default class GlobalFilterFilterItem extends Component {
   @service site;
+  @service siteSettings;
 
   @tracked spacedTag = this.args.filter.replace(/-|_/g, " ");
-  totalFilterTagCount =
-    this.site.filter_tags_total_topic_count[this.args.filter];
+
+  get totalFilterTagCount() {
+    const count = this.site.filter_tags_total_topic_count[this.args.filter];
+    const defaultLocale =
+      this.siteSettings.default_locale.replace(/_/g, "-") || "en-US";
+
+    return count.toLocaleString(defaultLocale);
+  }
 
   constructor() {
     super(...arguments);

--- a/assets/javascripts/discourse/components/global-filter/filter-item.js
+++ b/assets/javascripts/discourse/components/global-filter/filter-item.js
@@ -12,7 +12,7 @@ export default class GlobalFilterFilterItem extends Component {
   get totalFilterTagCount() {
     const count = this.site.filter_tags_total_topic_count[this.args.filter];
     const defaultLocale =
-      this.siteSettings.default_locale.replace(/_/g, "-") || "en-US";
+      this.siteSettings.default_locale?.replace(/_/g, "-") || "en-US";
 
     return count.toLocaleString(defaultLocale);
   }

--- a/test/javascripts/acceptance/global-filter-context-test.js
+++ b/test/javascripts/acceptance/global-filter-context-test.js
@@ -4,7 +4,9 @@ import { test } from "qunit";
 
 acceptance("Discourse Global Filter - Context", function (needs) {
   needs.user({ custom_fields: { global_filter_preference: "support" } });
-  needs.site({ filter_tags_total_topic_count: 0 });
+  needs.site({
+    filter_tags_total_topic_count: { support: 1, feature: 1 },
+  });
   needs.settings({
     discourse_global_filter_enabled: true,
     global_filters: "support|feature",

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -7,7 +7,9 @@ acceptance(
   "Discourse Global Filter - Filter Preference Initializer",
   function (needs) {
     needs.user({ custom_fields: { global_filter_preference: "support" } });
-    needs.site({ filter_tags_total_topic_count: 0 });
+    needs.site({
+      filter_tags_total_topic_count: { support: 1, feature: 1 },
+    });
     needs.settings({
       discourse_global_filter_enabled: true,
       global_filters: "support|feature",

--- a/test/javascripts/acceptance/require-tag-on-topic-creation-test.js
+++ b/test/javascripts/acceptance/require-tag-on-topic-creation-test.js
@@ -16,7 +16,10 @@ acceptance(
       admin: true,
       custom_fields: { global_filter_preference: "support" },
     });
-    needs.site({ filter_tags_total_topic_count: 0, can_tag_topics: true });
+    needs.site({
+      filter_tags_total_topic_count: { support: 1, feature: 1 },
+      can_tag_topics: true,
+    });
     needs.settings({
       discourse_global_filter_enabled: true,
       global_filters: "support|feature",

--- a/test/javascripts/acceptance/set-category-drop-options-test.js
+++ b/test/javascripts/acceptance/set-category-drop-options-test.js
@@ -18,8 +18,9 @@ acceptance(
       slug: "amazeCat",
       permission: 1,
     };
+
     needs.site({
-      filter_tags_total_topic_count: 0,
+      filter_tags_total_topic_count: { support: 1, feature: 1 },
       categories: [
         mazeCategory,
         {

--- a/test/javascripts/components/global-filter-container-test.js
+++ b/test/javascripts/components/global-filter-container-test.js
@@ -7,7 +7,9 @@ acceptance("Discourse Global Filter - Filter Container", function (needs) {
     discourse_global_filter_enabled: true,
     global_filters: "support",
   });
-  needs.site({ filter_tags_total_topic_count: 0 });
+  needs.site({
+    filter_tags_total_topic_count: { support: 1 },
+  });
   needs.user({ custom_fields: { global_filter_preference: "support" } });
 
   needs.pretender((server, helper) => {

--- a/test/javascripts/components/global-filter-item-test.js
+++ b/test/javascripts/components/global-filter-item-test.js
@@ -8,7 +8,7 @@ import { test } from "qunit";
 
 acceptance("Discourse Global Filter - Filter Item", function (needs) {
   needs.user();
-  needs.site({ filter_tags_total_topic_count: 0 });
+  needs.site({ filter_tags_total_topic_count: { support: 1, feature: 1 } });
   needs.settings({
     discourse_global_filter_enabled: true,
     global_filters: "support|feature",
@@ -202,10 +202,11 @@ acceptance("Discourse Global Filter - Filter Item", function (needs) {
   test("is present when included in global_filters", async function (assert) {
     await visit("/");
     let tags = [];
-    queryAll(".global-filter-container .global-filter-item").each((_, el) =>
-      tags.push(el.innerText.trim())
-    );
-    assert.deepEqual(tags, this.siteSettings.global_filters.split("|"));
+    queryAll(".global-filter-container .global-filter-item").each((_, el) => {
+      // strip new lines to test values
+      tags.push(el.innerText.replace(/\n/g, " "));
+    });
+    assert.deepEqual(tags, ["support 1", "feature 1"]);
   });
 
   test("adds active class to filter", async function (assert) {

--- a/test/javascripts/components/global-filter/composer-container-test.js
+++ b/test/javascripts/components/global-filter/composer-container-test.js
@@ -8,7 +8,9 @@ acceptance("Discourse Global Filter - Composer Container", function (needs) {
     global_filters: "support",
   });
   needs.user({ custom_fields: { global_filter_preference: "support" } });
-  needs.site({ filter_tags_total_topic_count: 0 });
+  needs.site({
+    filter_tags_total_topic_count: { support: 1 },
+  });
 
   needs.pretender((server, helper) => {
     server.get(

--- a/test/javascripts/components/global-filter/composer-item-test.js
+++ b/test/javascripts/components/global-filter/composer-item-test.js
@@ -12,7 +12,10 @@ acceptance("Discourse Global Filter - Composer Item", function (needs) {
     discourse_global_filter_enabled: true,
     global_filters: "support|feature",
   });
-  needs.site({ can_tag_topics: true, filter_tags_total_topic_count: 0 });
+  needs.site({
+    can_tag_topics: true,
+    filter_tags_total_topic_count: { support: 1, feature: 1 },
+  });
 
   needs.pretender((server, helper) => {
     ["support", "feature"].forEach((tag) => {

--- a/test/javascripts/components/global-filter/filtered-tags-chooser-test.js
+++ b/test/javascripts/components/global-filter/filtered-tags-chooser-test.js
@@ -9,7 +9,9 @@ acceptance("Discourse Global Filter - Filtered Tags Chooser", function (needs) {
     global_filters: "support|feature",
     tagging_enabled: true,
   });
-  needs.site({ filter_tags_total_topic_count: 0 });
+  needs.site({
+    filter_tags_total_topic_count: { support: 1, feature: 1 },
+  });
 
   needs.pretender((server, helper) => {
     server.get("/tag/support/l/latest.json", () => {


### PR DESCRIPTION
As per [Meta request](https://meta.discourse.org/t/epic-ongoing-work-tracker/216708/481?u=keegan), this PR updates appearance of the topic count on filter tags so they are rendered based on locale (typically with commas).

So that `427075` is rendered as `427,075`

<img width="165" alt="Screenshot 2023-01-24 at 11 34 48" src="https://user-images.githubusercontent.com/30090424/214390959-07eacadc-f453-467a-a680-a6ff45ea3fdc.png">
