### PR TITLE
DEV: Set a default global filter for usage in admin/user summary

### DIFF
--- a/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
+++ b/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
@@ -43,25 +43,17 @@ export default {
     }
 
     if (!tags) {
+      // Use first global filter as default
+      this._setSiteGlobalFilter(globalFilters[0]);
       return;
     }
 
     globalFilters.forEach((item) => {
-      const filterBodyClass = `global-filter-tag-${item}`;
-
       if (item === tags) {
-        document
-          .querySelector(`#global-filter-${item} > a`)
-          .classList.add("active");
-        document.body.classList.add(filterBodyClass);
-        Site.current().set("globalFilter", item);
-        return;
+        this._setSiteGlobalFilter(item);
       }
 
-      document
-        .querySelector(`#global-filter-${item} > a`)
-        .classList.remove("active");
-      document.body.classList.remove(filterBodyClass);
+      this._removeSiteGlobalFilter(item);
     });
   },
 
@@ -78,5 +70,21 @@ export default {
     }
 
     return tags;
+  },
+
+  _setSiteGlobalFilter(filter) {
+    document
+      .querySelector(`#global-filter-${filter} > a`)
+      .classList.add("active");
+    document.body.classList.add(`global-filter-tag-${filter}`);
+    Site.current().set("globalFilter", filter);
+    return;
+  },
+
+  _removeSiteGlobalFilter(filter) {
+    document
+      .querySelector(`#global-filter-${filter} > a`)
+      .classList.remove("active");
+    document.body.classList.remove(`global-filter-tag-${filter}`);
   },
 };


### PR DESCRIPTION
This PR sets a default global filter to be the first of a site's global filters. This is important for usage in areas such as the admin panel or user page. When someone directly visits a page by directly going to a URL such as `/u/${username}/summary`, or clicks into the admin panel, there is no global filter set for the site. This can cause issues because sites may rely on the property `site.globalFilter` for certain links and having no global filter results in the `site.globalFilter` being `undefined` and thereby breaking many links.