### PR TITLE
FIX: Regression on category matrix selections

### DIFF
--- a/assets/javascripts/discourse/components/category-matrix-checkbox.js
+++ b/assets/javascripts/discourse/components/category-matrix-checkbox.js
@@ -16,9 +16,11 @@ export default Component.extend({
 
   @action
   onChange(e) {
-    let categoryIds = this.filterTag.category_ids
-      .split("|")
-      .map((str) => Number(str));
+    const splitFilterCategoryIds = this.filterTag.category_ids;
+    let categoryIds =
+      splitFilterCategoryIds === ""
+        ? []
+        : this.filterTag.category_ids.split("|").map((str) => Number(str));
 
     if (e.target.checked) {
       categoryIds.push(this.category.get("id"));


### PR DESCRIPTION
When no category ids are present on a global filter,`this.filterTag.category_ids` returns `""`.  When trying to map and split this empty string to convert the possible string values to integers we do

```
.map((str) => Number(str));
```

The problem was that `Number("")` evaluates to `0`. This broke our topic filtering logic as you could not leave the category_ids section blank for a Global Filter, it was always assigning `0` at the minimum. This did not allow for the _Leave every checkbox blank to select all categories_ functionality.