### PR TITLE
DEV: Update plugin outlet declaration

### DIFF
--- a/assets/javascripts/discourse/components/global-filter-container.hbs
+++ b/assets/javascripts/discourse/components/global-filter-container.hbs
@@ -1,5 +1,5 @@
 {{#if this.globalFilters}}
-  {{plugin-outlet name="above-global-filter-container"}}
+  <PluginOutlet @name="above-global-filter-container" />
   <div class="global-filter-button-container">
     {{#each globalFilters as |filter|}}
       <GlobalFilter::FilterItem @filter={{filter}} />

--- a/assets/javascripts/discourse/components/global-filter/filter-item.hbs
+++ b/assets/javascripts/discourse/components/global-filter/filter-item.hbs
@@ -15,7 +15,7 @@
     </span>
   </a>
 </div>
-  <PluginOutlet
-    @name="below-global-filter-item"
-    @outletArgs={{hash filter=@filter.name}}
-  />
+<PluginOutlet
+  @name="below-global-filter-item"
+  @outletArgs={{hash filter=@filter.name}}
+/>

--- a/assets/javascripts/discourse/components/global-filter/filter-item.hbs
+++ b/assets/javascripts/discourse/components/global-filter/filter-item.hbs
@@ -14,8 +14,8 @@
       </span>
     </span>
   </a>
-  {{plugin-outlet
-    name="below-global-filter-item"
-    args=(hash filter=@filter.name)
-  }}
 </div>
+  <PluginOutlet
+    @name="below-global-filter-item"
+    @outletArgs={{hash filter=@filter.name}}
+  />


### PR DESCRIPTION
This PR updates the usage of the plugin outlet component to get rid of the deprecation warning:

```js
Deprecation notice: PluginOutlet arguments should now be passed using `@outletArgs=` instead of `@args=` (outlet: below-global-filter-item) [deprecation id: discourse.plugin-outlet-args]
```