### PR TITLE
FIX: Minor fixes to improve overriding in themes 

### DIFF
--- a/assets/javascripts/select-kit/addon/components/global-filter-chooser-row.js
+++ b/assets/javascripts/select-kit/addon/components/global-filter-chooser-row.js
@@ -22,10 +22,6 @@ export default SelectKitRowComponent.extend({
       return I18n.t("select_kit.create", { content: label });
     }
 
-    return this._tagName(label);
-  },
-
-  _tagName(filter) {
     return (
       this.item.alternate_name || this.item.name?.replace(/-|_/g, " ") || ""
     );

--- a/assets/javascripts/select-kit/addon/components/global-filter-chooser-row.js
+++ b/assets/javascripts/select-kit/addon/components/global-filter-chooser-row.js
@@ -26,12 +26,8 @@ export default SelectKitRowComponent.extend({
   },
 
   _tagName(filter) {
-    const currentFilter = this.site.global_filters.findBy("name", filter);
-
     return (
-      currentFilter.alternate_name ||
-      currentFilter.name?.replace(/-|_/g, " ") ||
-      ""
+      this.item.alternate_name || this.item.name?.replace(/-|_/g, " ") || ""
     );
   },
 });

--- a/assets/javascripts/select-kit/addon/components/global-filter-chooser.js
+++ b/assets/javascripts/select-kit/addon/components/global-filter-chooser.js
@@ -1,4 +1,5 @@
 import MultiSelectComponent from "select-kit/components/multi-select";
+import { computed } from "@ember/object";
 
 export default MultiSelectComponent.extend({
   pluginApiIdentifiers: ["global-filter-chooser"],
@@ -13,7 +14,7 @@ export default MultiSelectComponent.extend({
   },
 
   get content() {
-    return this.site.global_filters;
+    return this.site?.global_filters;
   },
 
   _tagName(filter) {

--- a/assets/javascripts/select-kit/addon/components/global-filter-chooser.js
+++ b/assets/javascripts/select-kit/addon/components/global-filter-chooser.js
@@ -1,5 +1,4 @@
 import MultiSelectComponent from "select-kit/components/multi-select";
-import { computed } from "@ember/object";
 
 export default MultiSelectComponent.extend({
   pluginApiIdentifiers: ["global-filter-chooser"],
@@ -15,9 +14,5 @@ export default MultiSelectComponent.extend({
 
   get content() {
     return this.site?.global_filters;
-  },
-
-  _tagName(filter) {
-    return filter.alternate_name || filter.name?.replace(/-|_/g, " ") || "";
   },
 });


### PR DESCRIPTION
**This PR updates the plugin to have some minor fixes to improve overriding in themes.**

Specifically it:
- Ensures `site` object is defined before checking for global filters (not doing this results in undefined errors when using `modifyClass()` in themes/components)
- Simplifies assigning `alternate_name` for tag names with alternate names. There is no need to find and filter the `site.global_filters` for the current item since the `item` object is already present with its data.