### PR TITLE
DEV: Add plugin outlets inside `filtered-tags-chooser` component

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/filtered-tags-chooser.hbs
+++ b/assets/javascripts/discourse/components/global-filter/filtered-tags-chooser.hbs
@@ -1,3 +1,4 @@
+<PluginOutlet @name="before-filtered-tags-chooser" />
 {{#each @categoryBreadcrumbs as |breadcrumb|}}
   {{#if breadcrumb.hasOptions}}
     <li
@@ -8,6 +9,10 @@
           "gft-parent-categories-drop"
         }}"
     >
+      <PluginOutlet
+        @name="before-filtered-category-drop"
+        @outletArgs={{hash category=breadcrumb.category}}
+      />
       <CategoryDrop
         @category={{breadcrumb.category}}
         @categories={{breadcrumb.options}}
@@ -37,6 +42,10 @@
     </li>
   {{else}}
     <li class="filtered-tag-drop">
+      <PluginOutlet
+        @name="before-filtered-tag-drop"
+        @outletArgs={{hash tags=@tagId additionalTags=@additionalTags}}
+      />
       <TagDrop
         @currentCategory={{@category}}
         @noSubcategories={{@noSubcategories}}


### PR DESCRIPTION
This PR adds plugin outlets to the `<FilteredTagsChooser />` component for easy customization.