### PR TITLE
DEV: On mobile show tags chooser outside the dropdown

### DIFF
--- a/assets/javascripts/discourse/connectors/inline-extra-nav-item/filtered-tags-chooser.hbs
+++ b/assets/javascripts/discourse/connectors/inline-extra-nav-item/filtered-tags-chooser.hbs
@@ -1,4 +1,4 @@
-{{#if this.site.desktopView}}
+{{#if this.site.mobileView}}
   <GlobalFilter::FilteredTagsChooser
     @currentCategory={{this.category}}
     @options={{hash categoryId=this.category.id}}

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -50,6 +50,15 @@ ol.category-breadcrumb > li:nth-child(-n + 2) {
   display: none;
 }
 
+.mobile-view {
+  .nav.nav-pills {
+    .inline-extra-nav-item-outlet.filtered-tags-chooser {
+      margin-left: 0.5rem;
+      border: none;
+    }
+  }
+}
+
 .alternate-filter-name-picker-wrapper {
   display: flex;
   flex-wrap: wrap;

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -55,6 +55,10 @@ ol.category-breadcrumb > li:nth-child(-n + 2) {
     .inline-extra-nav-item-outlet.filtered-tags-chooser {
       margin-left: 0.5rem;
       border: none;
+
+      .filtered-tag-drop .tag-drop {
+        height: 100%;
+      }
     }
   }
 }


### PR DESCRIPTION
This PR takes advantage of the new [plugin outlet `inline-extra-nav-item`](https://github.com/discourse/discourse/pull/21437) to move the filtered tag chooser outside of the dropdown and next to it instead.

**Before:**
![Screenshot 2023-05-08 at 11 40 26](https://user-images.githubusercontent.com/30090424/236905290-7021faa6-8993-42f1-8f20-26ec49ccaac3.png)

**After:**
![Screenshot 2023-05-08 at 11 38 53](https://user-images.githubusercontent.com/30090424/236904641-54fb37aa-9265-4962-8b48-421bc6489688.png)
