### PR TITLE
FIX: /login loop when categories is default homepage

### DIFF
--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -1,4 +1,4 @@
-import { run } from "@ember/runloop";
+import { next, run } from "@ember/runloop";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
@@ -134,10 +134,9 @@ export default {
           url = `/tags/intersection/${filterPref}/${additionalTags}`;
           router.transitionTo(url, null, { queryParams });
         } else if (transition.to?.localName === "categories") {
-          transition.abort();
-          router.transitionTo(`/categories?tag=${filterPref}`);
+          next(() => router.transitionTo(`/categories?tag=${filterPref}`));
         } else if (transition.to?.name === "discovery.latest") {
-          router.transitionTo(`/tag/${filterPref}`, null, { queryParams });
+          router.transitionTo("tag.show", filterPref, { queryParams });
         } else {
           const categoryURL = categorySlug ? `s/c/${categorySlug}` : "";
           url = `/tag${categoryURL}/${filterPref}`;

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -196,5 +196,16 @@ acceptance(
         "it redirects to the user's global_filter_preference"
       );
     });
+
+    test("/login works with categories as default homepage", async function (assert) {
+      setDefaultHomepage("categories");
+      await visit("/login");
+
+      assert.equal(
+        currentURL(),
+        "/categories?tag=support",
+        "it redirects to the user's global_filter_preference"
+      );
+    });
   }
 );


### PR DESCRIPTION
`/login` is going into an infinite loop if the categories list is set as default homepage.

This PR fixes it by not aborting the current transition and only redirecting on the `next` cycle.

It also fixes a test failure that has been happening for [~2 months.](https://github.com/discourse/discourse-global-filter/actions)

For reference, the removed `transition.abort()` call was probably intended as a workaround for this (still open) Ember issue: https://github.com/emberjs/ember.js/issues/18577