### PR TITLE
FIX: infer global filter from /new-topic tags query param

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/header.js
+++ b/assets/javascripts/discourse/components/global-filter/header.js
@@ -1,3 +1,3 @@
-import ComboBoxSelectBoxHeaderComponent from "select-kit/components/combo-box/combo-box-header";
+import MultiSelectHeaderComponent from "select-kit/components/multi-select/multi-select-header";
 
-export default ComboBoxSelectBoxHeaderComponent.extend({});
+export default MultiSelectHeaderComponent.extend({});

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -34,7 +34,7 @@ export default {
       let tagFromNewTopic
 
       // on a /new-topic?tags=x route, determine if x is a globalFilter or a child of one
-      if (routeName === "new-topic") {
+      if (routeName === "new-topic" && currentUser) {
         const tags = transition.to?.queryParams?.tags?.split(",");
 
         if (tags) {

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -31,14 +31,12 @@ export default {
     router.on("routeWillChange", (transition) => {
       const routeName = transition.to?.name;
 
-      let tagFromNewTopic;
-
       // on a /new-topic?tags=x route, determine if x is a globalFilter or a child of one
       if (routeName === "new-topic" && currentUser) {
         const tags = transition.to?.queryParams?.tags?.split(",");
 
         if (tags) {
-          tagFromNewTopic = tags.find((tag) => globalFilters.includes(tag));
+          let tagFromNewTopic = tags.find((tag) => globalFilters.includes(tag));
 
           if (!tagFromNewTopic) {
             const site = container.lookup("site:main");

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -31,7 +31,7 @@ export default {
     router.on("routeWillChange", (transition) => {
       const routeName = transition.to?.name;
 
-      let tagFromNewTopic
+      let tagFromNewTopic;
 
       // on a /new-topic?tags=x route, determine if x is a globalFilter or a child of one
       if (routeName === "new-topic" && currentUser) {
@@ -43,11 +43,18 @@ export default {
           if (!tagFromNewTopic) {
             const site = container.lookup("site:main");
 
-            const globalFilterFromChildren = site.global_filters.find((globalFilter) => {
-              return globalFilter.filter_children && Object.keys(globalFilter.filter_children).some((childTag) => tags.includes(childTag));
-            })
+            const globalFilterFromChildren = site.global_filters.find(
+              (globalFilter) => {
+                return (
+                  globalFilter.filter_children &&
+                  Object.keys(globalFilter.filter_children).some((childTag) =>
+                    tags.includes(childTag)
+                  )
+                );
+              }
+            );
 
-            tagFromNewTopic = globalFilterFromChildren?.name
+            tagFromNewTopic = globalFilterFromChildren?.name;
           }
 
           if (tagFromNewTopic) {
@@ -146,7 +153,7 @@ export default {
     let url;
     run(router, function () {
       // omit `tags` from redirects if passed from /new-topic, we're already enforcing a tag
-      const { tags, ...queryParams} = transition?.to?.queryParams;
+      const queryParams = transition?.to?.queryParams;
       const categorySlug = transition.to?.params?.category_slug_path_with_id;
 
       if (

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -150,7 +150,6 @@ export default {
   ) {
     let url;
     run(router, function () {
-      // omit `tags` from redirects if passed from /new-topic, we're already enforcing a tag
       const queryParams = transition?.to?.queryParams;
       const categorySlug = transition.to?.params?.category_slug_path_with_id;
 

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -1,5 +1,9 @@
 import { click, currentURL, visit } from "@ember/test-helpers";
-import { acceptance, query, updateCurrentUser } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  query,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { setDefaultHomepage } from "discourse/lib/utilities";
 
@@ -9,14 +13,16 @@ acceptance(
     needs.user();
 
     needs.hooks.beforeEach(() => {
-      updateCurrentUser({ custom_fields: { global_filter_preference: "support" } });
+      updateCurrentUser({
+        custom_fields: { global_filter_preference: "support" },
+      });
     });
 
     needs.site({
       filter_tags_total_topic_count: { support: 1, feature: 1 },
       global_filters: [
         { id: 1, name: "support" },
-        { id: 2, name: "feature", filter_children: { "bug-report": { } } },
+        { id: 2, name: "feature", filter_children: { "bug-report": {} } },
       ],
     });
     needs.settings({
@@ -51,7 +57,7 @@ acceptance(
             topics: [],
           },
         });
-      }
+      };
 
       server.get("/tags/intersection/support/blog.json", emptyResponseHandler);
 
@@ -183,19 +189,17 @@ acceptance(
     test("global filter tags used on /new-topic", async function (assert) {
       await visit("/new-topic?tags=feature");
 
-      assert.equal(
-        currentURL(),
-        "/tag/feature",
-        "it redirects to the global filter used in the new-topic tags query param"
+      assert.ok(
+        document.body.classList.contains("global-filter-tag-feature"),
+        "it navigates to the global filter used in the new-topic tags query param"
       );
     });
 
     test("child tag of global filter used on /new-topic", async function (assert) {
       await visit("/new-topic?tags=bug-report");
 
-      assert.equal(
-        currentURL(),
-        "/tag/feature",
+      assert.ok(
+        document.body.classList.contains("global-filter-tag-feature"),
         "it redirects to the global filter if the new-topic tags query param is a child of one"
       );
     });

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -1,17 +1,22 @@
 import { click, currentURL, visit } from "@ember/test-helpers";
-import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance, query, updateCurrentUser } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { setDefaultHomepage } from "discourse/lib/utilities";
 
 acceptance(
   "Discourse Global Filter - Filter Preference Initializer",
   function (needs) {
-    needs.user({ custom_fields: { global_filter_preference: "support" } });
+    needs.user();
+
+    needs.hooks.beforeEach(() => {
+      updateCurrentUser({ custom_fields: { global_filter_preference: "support" } });
+    });
+
     needs.site({
       filter_tags_total_topic_count: { support: 1, feature: 1 },
       global_filters: [
         { id: 1, name: "support" },
-        { id: 2, name: "feature" },
+        { id: 2, name: "feature", filter_children: { "bug-report": { } } },
       ],
     });
     needs.settings({
@@ -26,23 +31,13 @@ acceptance(
         })
       );
 
-      server.get("/tags/intersection/support/blog.json", () => {
-        return helper.response({
-          users: [],
-          primary_groups: [],
-          topic_list: {
-            can_create_topic: true,
-            draft: null,
-            draft_key: "new_topic",
-            draft_sequence: 1,
-            per_page: 30,
-            tags: [],
-            topics: [],
-          },
-        });
-      });
+      server.get("/tag/feature/notifications", () =>
+        helper.response({
+          tag_notification: { id: "feature", notification_level: 2 },
+        })
+      );
 
-      server.get("/tag/support/l/top.json", () => {
+      const emptyResponseHandler = () => {
         return helper.response({
           users: [],
           primary_groups: [],
@@ -56,39 +51,16 @@ acceptance(
             topics: [],
           },
         });
-      });
+      }
 
-      server.get("/tag/support/l/latest.json", () => {
-        return helper.response({
-          users: [],
-          primary_groups: [],
-          topic_list: {
-            can_create_topic: true,
-            draft: null,
-            draft_key: "new_topic",
-            draft_sequence: 1,
-            per_page: 30,
-            tags: [],
-            topics: [],
-          },
-        });
-      });
+      server.get("/tags/intersection/support/blog.json", emptyResponseHandler);
 
-      server.get("/tag/blog/l/latest.json", () => {
-        return helper.response({
-          users: [],
-          primary_groups: [],
-          topic_list: {
-            can_create_topic: true,
-            draft: null,
-            draft_key: "new_topic",
-            draft_sequence: 1,
-            per_page: 30,
-            tags: [],
-            topics: [],
-          },
-        });
-      });
+      server.get("/tag/support/l/top.json", emptyResponseHandler);
+      server.get("/tag/support/l/latest.json", emptyResponseHandler);
+
+      server.get("/tag/blog/l/latest.json", emptyResponseHandler);
+
+      server.get("/tag/feature/l/latest.json", emptyResponseHandler);
 
       server.put("/global_filter/filter_tags/support/assign.json", () => {
         return helper.response({ success: true });
@@ -205,6 +177,26 @@ acceptance(
         currentURL(),
         "/categories?tag=support",
         "it redirects to the user's global_filter_preference"
+      );
+    });
+
+    test("global filter tags used on /new-topic", async function (assert) {
+      await visit("/new-topic?tags=feature");
+
+      assert.equal(
+        currentURL(),
+        "/tag/feature",
+        "it redirects to the global filter used in the new-topic tags query param"
+      );
+    });
+
+    test("child tag of global filter used on /new-topic", async function (assert) {
+      await visit("/new-topic?tags=bug-report");
+
+      assert.equal(
+        currentURL(),
+        "/tag/feature",
+        "it redirects to the global filter if the new-topic tags query param is a child of one"
       );
     });
   }


### PR DESCRIPTION
When we navigate to a `/new-topic` route with `tags` query params, we may be on the topic creation flow for a given global filter but we weren't navigating to it.

This PR sets the preferred global filter for the current user by inferring it from the passed `tags`:
* if one of the tags in `tags` is an existing global filter
* if one of the tags in `tags` is a child to an existing global filter