### PR TITLE
FIX: add parent global filter tag on /new-topic

### DIFF
--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -52,7 +52,11 @@ export default {
               }
             );
 
-            tagFromNewTopic = globalFilterFromChildren?.name;
+            if (globalFilterFromChildren) {
+              tagFromNewTopic = globalFilterFromChildren.name;
+
+              transition.to.queryParams.tags += `,${tagFromNewTopic}`;
+            }
           }
 
           if (tagFromNewTopic) {

--- a/test/javascripts/components/global-filter/composer-item-test.js
+++ b/test/javascripts/components/global-filter/composer-item-test.js
@@ -100,7 +100,7 @@ acceptance(
       await selectKit(".global-filter-chooser").selectRowByValue("feature");
 
       let composer = this.owner.lookup("controller:composer");
-      assert.ok(
+      assert.deepEqual(
         composer.get("model").tags,
         ["feature"],
         "expected filter is present"


### PR DESCRIPTION
If a child of a global filter tag is used on `/new-topic?tags=x`, add the parent tag to the list.