### PR TITLE
UX: respect global filter matrix when filtering category drop

### DIFF
--- a/assets/javascripts/discourse/initializers/set-category-drop-options.js
+++ b/assets/javascripts/discourse/initializers/set-category-drop-options.js
@@ -58,32 +58,54 @@ function setCategoryDropOptionsPerGlobalFilter(api) {
           ];
         }
 
-        if (!categoryDrop.selectKit.filter) {
-          const categoryDropParentClasslist = document.getElementById(
-            categoryDrop.elementId
-          ).parentElement.classList;
+        let content = categoryDrop.content || [];
+        if (categoryDrop.selectKit.filter) {
+          const filter = categoryDrop.selectKit.filter.toLowerCase();
 
-          if (
-            categoryDropParentClasslist.contains("gft-parent-categories-drop")
-          ) {
-            return categoriesAndSubcategories.categories;
-          }
+          content = content.filter((c) => {
+            const name = categoryDrop.getName(c)?.toLowerCase();
+            return name?.includes(filter);
+          });
+        }
 
-          if (categoryDropParentClasslist.contains("gft-subcategories-drop")) {
-            const filteredSubcategories = categoryDrop.content.filter((c) => {
-              const categoriesByName =
-                categoriesAndSubcategories.subcategories.map(
-                  (item) => item["name"]
-                );
+        const categoryDropParentClasslist = document.getElementById(
+          categoryDrop.elementId
+        ).parentElement.classList;
 
-              return categoriesByName.includes(
-                c.name ||
-                  categoryDrop.allCategoriesLabel ||
-                  categoryDrop.noCategoriesLabel
-              );
-            });
-            return filteredSubcategories;
-          }
+        const isParentCategoryDrop = categoryDropParentClasslist.contains(
+          "gft-parent-categories-drop"
+        );
+        if (isParentCategoryDrop) {
+          const filteredCategories = content.filter((c) => {
+            const categoriesByName = categoriesAndSubcategories.categories.map(
+              (item) => item.name
+            );
+
+            return categoriesByName.includes(
+              c.name ||
+              categoryDrop.allCategoriesLabel ||
+              categoryDrop.noCategoriesLabel
+            );
+          });
+          return filteredCategories;
+        }
+
+        const isSubcategoriesDrop = categoryDropParentClasslist.contains(
+          "gft-subcategories-drop"
+        );
+        if (isSubcategoriesDrop) {
+          const filteredSubcategories = content.filter((c) => {
+            const categoryNames = categoriesAndSubcategories.subcategories.map(
+              (item) => item.name
+            );
+
+            return categoryNames.includes(
+              c.name ||
+              categoryDrop.allCategoriesLabel ||
+              categoryDrop.noCategoriesLabel
+            );
+          });
+          return filteredSubcategories;
         }
       });
     }

--- a/test/javascripts/acceptance/set-category-drop-options-test.js
+++ b/test/javascripts/acceptance/set-category-drop-options-test.js
@@ -17,6 +17,14 @@ acceptance(
       name: "amazeCat",
       slug: "amazeCat",
       permission: 1,
+      has_children: true,
+    };
+
+    const sadCat = {
+      id: 101,
+      name: "sadCat",
+      slug: "sadCat",
+      permission: 1,
     };
 
     needs.site({
@@ -27,12 +35,7 @@ acceptance(
       ],
       categories: [
         mazeCategory,
-        {
-          id: 101,
-          name: "sadCat",
-          slug: "sadCat",
-          permission: 1,
-        },
+        sadCat,
         {
           id: 102,
           name: "happyCat",
@@ -77,7 +80,7 @@ acceptance(
         "/global_filter/filter_tags/categories_for_current_filter.json",
         () =>
           helper.response({
-            categories: [{ id: 100 }, { id: 101 }],
+            categories: [mazeCategory, sadCat],
             subcategories: [{ id: 102, name: "happyCat" }],
           })
       );
@@ -105,17 +108,22 @@ acceptance(
       assert.strictEqual(categories.rows().length, 1);
     });
 
-    test("does not limit options to GFT categories when filtering", async function (assert) {
+    test("limits options to GFT categories when filtering", async function (assert) {
       await visit("/categories");
       const categories = selectKit(
         ".gft-parent-categories-drop .category-drop"
       );
       await categories.expand();
-      await categories.fillInFilter("general");
+      await categories.fillInFilter("amaze");
 
       assert.ok(
-        categories.rowByName("generalCat").exists(),
-        "include all categories when filtering"
+        categories.rowByName("amazeCat").exists(),
+        "include category with term when filtering"
+      );
+
+      assert.ok(
+        !categories.rowByName("grumpyCat").exists(),
+        "does not include all categories when filtering"
       );
     });
   }


### PR DESCRIPTION
Adds a simple name match, filtering the allowed categories for the current "global filter" when a filter term is entered in the category drop.

This is a behavior change, but it is aligned with what we do everywhere else – avoid UI flows for non-allowed categories for a given global filter.