### PR TITLE
FIX: routing on /new-topic and /categories

### DIFF
--- a/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
+++ b/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
@@ -44,7 +44,7 @@ export default {
 
     if (!tags) {
       // Use first global filter as default
-      this._setSiteGlobalFilter(globalFilters[0]);
+      this._setSiteGlobalFilter(filterPref ?? globalFilters[0]);
       return;
     }
 

--- a/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
+++ b/assets/javascripts/discourse/initializers/apply-global-filter-styles.js
@@ -43,7 +43,6 @@ export default {
     }
 
     if (!tags) {
-      // Use first global filter as default
       this._setSiteGlobalFilter(filterPref ?? globalFilters[0]);
       return;
     }

--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -57,7 +57,6 @@ export default {
 
           if (tagFromNewTopic) {
             this._setClientFilterPref(tagFromNewTopic, currentUser);
-            return;
           }
         }
       }

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -59,6 +59,8 @@ acceptance(
         });
       };
 
+      const successResponseHandler = () => helper.response({ success: true });
+
       server.get("/tags/intersection/support/blog.json", emptyResponseHandler);
 
       server.get("/tag/support/l/top.json", emptyResponseHandler);
@@ -68,15 +70,18 @@ acceptance(
 
       server.get("/tag/feature/l/latest.json", emptyResponseHandler);
 
-      server.put("/global_filter/filter_tags/support/assign.json", () => {
-        return helper.response({ success: true });
-      });
+      server.put(
+        "/global_filter/filter_tags/support/assign.json",
+        successResponseHandler
+      );
+      server.put(
+        "/global_filter/filter_tags/feature/assign.json",
+        successResponseHandler
+      );
 
       server.get(
         "/global_filter/filter_tags/categories_for_current_filter.json",
-        () => {
-          return helper.response({ success: true });
-        }
+        successResponseHandler
       );
     });
 
@@ -201,6 +206,30 @@ acceptance(
       assert.ok(
         document.body.classList.contains("global-filter-tag-feature"),
         "it redirects to the global filter if the new-topic tags query param is a child of one"
+      );
+    });
+
+    test("uses stored global filter preference at /", async function (assert) {
+      setDefaultHomepage("categories");
+      await visit("/categories?tag=feature");
+
+      assert.equal(
+        currentURL(),
+        "/categories?tag=feature",
+        "it navigates to the global filter"
+      );
+
+      await visit("/");
+
+      assert.equal(
+        currentURL(),
+        "/categories?tag=feature",
+        "it navigates to the stored global filter preference"
+      );
+
+      assert.ok(
+        document.body.classList.contains("global-filter-tag-feature"),
+        "it shows the global filter preference app"
       );
     });
   }


### PR DESCRIPTION
This is very hard to test, it was happening very intermittently:
* When visiting `/new-topic` with category and tags params, _sometimes_ it would render the wrong app, the 1st option instead of the one inferred from the tags param
* When visiting `/` or `/categories` after having visited a different global filter (which is stored as a preference), the presented data would be from the preferred app, but the "visually" selected app was the 1st option in the list