### PR TITLE
DEV: Update test guardian due to core change

### DIFF
--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -59,6 +59,6 @@ RSpec.describe CategoriesController do
   end
 
   it_behaves_like "#categories_and_topics" do
-    let(:guardian) { Guardian.anon_user }
+    let(:guardian) { Guardian.new(nil) }
   end
 end


### PR DESCRIPTION
`Guardian.anon` was removed here https://github.com/discourse/discourse/pull/24705. 

The `anon` word is overloaded, so we're replacing it with something more explicit.