### PR TITLE
FEATURE: include children filters on hidden tags

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/composer-container.js
+++ b/assets/javascripts/discourse/components/global-filter/composer-container.js
@@ -3,10 +3,6 @@ import { inject as service } from "@ember/service";
 
 export default class GlobalFilterComposerContainer extends Component {
   @service router;
-  @service site;
-  @service siteSettings;
-
-  tagParam = this.router.currentRoute?.queryParams?.tag;
 
   get canDisplay() {
     return (
@@ -15,9 +11,5 @@ export default class GlobalFilterComposerContainer extends Component {
       (this.args.composer.editingFirstPost === true &&
         !this.args.composer.privateMessage)
     );
-  }
-
-  get globalFilters() {
-    return this.site.global_filters;
   }
 }

--- a/assets/javascripts/discourse/components/global-filter/filtered-composer-tags-chooser.js
+++ b/assets/javascripts/discourse/components/global-filter/filtered-composer-tags-chooser.js
@@ -3,8 +3,15 @@ import { inject as service } from "@ember/service";
 
 export default class GlobalFilterFilteredComposerTagsChooser extends Component {
   @service siteSettings;
+  @service site;
 
   get hiddenValues() {
-    return this.siteSettings.global_filters.split("|");
+    const children = this.site.global_filters.flatMap((gf) =>
+      gf.filter_children ? Object.keys(gf.filter_children) : []
+    );
+
+    const globalFilters = this.siteSettings.global_filters.split("|");
+
+    return [...globalFilters, ...children];
   }
 }

--- a/assets/javascripts/select-kit/addon/components/global-filter-chooser.js
+++ b/assets/javascripts/select-kit/addon/components/global-filter-chooser.js
@@ -1,3 +1,4 @@
+import { computed } from "@ember/object";
 import MultiSelectComponent from "select-kit/components/multi-select";
 import { ajax } from "discourse/lib/ajax";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -14,25 +15,31 @@ export default MultiSelectComponent.extend({
   didInsertElement() {
     this._super(...arguments);
     this.setCategoriesForFilter();
-    this.setSelectedContentToFilter();
   },
 
   get filtersWithChildren() {
     return this.loadAdditionalFilters(this.site.global_filters);
   },
 
+  selectedContent: computed(
+    "value.[]",
+    "content.[]",
+    "filtersWithChildren.[]",
+    function () {
+      if (!this.value) {
+        return [];
+      }
+
+      return this.filtersWithChildren.filter((filterTag) =>
+        this.value.includes(filterTag.name)
+      );
+    }
+  ),
+
   get content() {
     if (!this.value) {
       return [];
     }
-
-    // set header selected values
-    this.set(
-      "selectedContent",
-      this.filtersWithChildren.filter((filterTag) =>
-        this.value.includes(filterTag.name)
-      )
-    );
 
     // set remaining dropdown content values
     return this.filtersWithChildren.filter(
@@ -50,19 +57,6 @@ export default MultiSelectComponent.extend({
     const updatedValues = this.value.filter((tag) => tag !== value.name);
     this.updateCategoryDropdown(updatedValues);
     this._super(...arguments);
-  },
-
-  setSelectedContentToFilter() {
-    if (!this.value) {
-      return [];
-    }
-
-    this.set(
-      "selectedContent",
-      this.filtersWithChildren.filter((filterTag) =>
-        this.value.includes(filterTag.name)
-      )
-    );
   },
 
   updateCategoryDropdown(tags) {


### PR DESCRIPTION
Include children filters when listing the hidden tags on `FilteredComposerTagsChooser`, so they're not selectable via the tag chooser.

Also removed `site`, `siteSettings`, `tagParam`, and `globalFilters` from `ComposerContainer` as they aren't used.