### PR TITLE
FIX: Don't error out when the tag in settings doesn't exist

### DIFF
--- a/spec/jobs/update_category_stats_spec.rb
+++ b/spec/jobs/update_category_stats_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GlobalFilter::UpdateCategoryStats do
+  describe "#perform" do
+    it "does not fail if site setting has non-existent tag name" do
+      SiteSetting.global_filters = "non-existent"
+
+      expect { GlobalFilter::UpdateCategoryStats.new.perform }.not_to raise_error
+    end
+  end
+end

--- a/spec/jobs/update_category_stats_spec.rb
+++ b/spec/jobs/update_category_stats_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 RSpec.describe GlobalFilter::UpdateCategoryStats do
   describe "#perform" do
     it "does not fail if site setting has non-existent tag name" do


### PR DESCRIPTION
We are currently seeing the following error at `update_category_stats.rb:20`

```
Job exception: undefined method `id' for nil:NilClass
```

This PR exits the job early if there are no tags, and only runs the updates through tags that exist.

Ideally, more tests can be added later for the job.