### PR TITLE
DEV: Add missing passkeys challenge pretender

### DIFF
--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -44,6 +44,10 @@ acceptance(
         })
       );
 
+      server.get("/session/passkey/challenge.json", () => {
+        return helper.response({});
+      });
+
       const emptyResponseHandler = () => {
         return helper.response({
           users: [],

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -45,7 +45,7 @@ acceptance(
       );
 
       server.get("/session/passkey/challenge.json", () => {
-        return helper.response({});
+        return helper.response({ challenge: "123" });
       });
 
       const emptyResponseHandler = () => {


### PR DESCRIPTION
Now that passkeys are default enabled, the `/login` modal triggers a challenge request that needs to be mocked.