### PR TITLE
DEV: Match an unordered array

### DIFF
--- a/spec/serializers/filter_tag_index_serializer_spec.rb
+++ b/spec/serializers/filter_tag_index_serializer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GlobalFilter::FilterTagIndexSerializer do
     json =
       GlobalFilter::FilterTagIndexSerializer.new(filter_tags: [filter_tag], root: false).as_json
     filter_tag_response = json[:filter_tag_index][:filter_tags][0]
-    expect(filter_tag_response[:categories].pluck(:id)).to eq(
+    expect(filter_tag_response[:categories].pluck(:id)).to match_array(
       filter_tag[:category_ids].split("|").map(&:to_i),
     )
   end


### PR DESCRIPTION
We shouldn't need to strictly match the order of the filter tags.

```
Failures:

  1) GlobalFilter::FilterTagIndexSerializer includes categories for filter_tags
     Failure/Error:
       expect(filter_tag_response[:categories].pluck(:id)).to eq(
         filter_tag[:category_ids].split("|").map(&:to_i),
       )
     
       expected: [49, 50]
            got: [50, 49]
     
       (compared using ==)
```