### PR TITLE
FIX: `update_category_stats` erroring on bad column lookup

### DIFF
--- a/jobs/scheduled/update_category_stats.rb
+++ b/jobs/scheduled/update_category_stats.rb
@@ -33,7 +33,7 @@ module Jobs
           posts =
             Post
               .joins(:topic)
-              .where(topics: { id: category_and_subcategory_topics.pluck(:id) })
+              .where(topics: { id: category_and_subcategory_topics.select(:id) })
               .where("topics.visible = true")
               .where("posts.deleted_at IS NULL")
               .where("posts.user_deleted = false")

--- a/jobs/scheduled/update_category_stats.rb
+++ b/jobs/scheduled/update_category_stats.rb
@@ -33,7 +33,7 @@ module Jobs
           posts =
             Post
               .joins(:topic)
-              .where(topics: category_and_subcategory_topics)
+              .where(topics: { id: category_and_subcategory_topics.pluck(:id) })
               .where("topics.visible = true")
               .where("posts.deleted_at IS NULL")
               .where("posts.user_deleted = false")


### PR DESCRIPTION
Internal: /t/135393

The `update_category_stats` job was failing due to a bad lookup of `topics` on the `Post` model.

This PR updates the job to lookup topics by `topic_id`.