### PR TITLE
DEV: Add back `FilteredTagsComposerChooser`

### DIFF
--- a/assets/javascripts/discourse/components/global-filter/filtered-tags-composer-chooser.gjs
+++ b/assets/javascripts/discourse/components/global-filter/filtered-tags-composer-chooser.gjs
@@ -1,0 +1,31 @@
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { service } from "@ember/service";
+import PopupInputTip from "discourse/components/popup-input-tip";
+import MiniTagChooser from "select-kit/components/mini-tag-chooser";
+
+export default class FilteredTagsComposerChooser extends Component {
+  @service siteSettings;
+  @service site;
+
+  get hiddenValues() {
+    const children = this.site.global_filters.flatMap((gf) =>
+      gf.filter_children ? Object.keys(gf.filter_children) : []
+    );
+    const globalFilters = this.siteSettings.global_filters.split("|");
+    return [...globalFilters, ...children];
+  }
+
+  <template>
+    <div class="tags-input filtered-tags-composer-chooser">
+      {{#if @canEditTags}}
+        <MiniTagChooser
+          @value={{@value}}
+          @onChange={{@onChange}}
+          @options={{hash @options hiddenValues=this.hiddenValues}}
+        />
+        <PopupInputTip @validation={{@tagValidation}} />
+      {{/if}}
+    </div>
+  </template>
+}

--- a/assets/javascripts/discourse/connectors/after-title-and-category/filtered-tags-chooser.gjs
+++ b/assets/javascripts/discourse/connectors/after-title-and-category/filtered-tags-chooser.gjs
@@ -1,0 +1,18 @@
+import { fn, hash } from "@ember/helper";
+import FilteredTagsComposerChooser from "../../components/global-filter/filtered-tags-composer-chooser";
+
+const FilteredTagsChooser = <template>
+  <FilteredTagsComposerChooser
+    @tagValidation={{@outletArgs.tagValidation}}
+    @canEditTags={{@outletArgs.canEditTags}}
+    @value={{@outletArgs.model.tags}}
+    @onChange={{fn (mut @outletArgs.model.tags)}}
+    @options={{hash
+      disabled=@outletArgs.disabled
+      categoryId=@outletArgs.model.categoryId
+      minimum=@outletArgs.model.minimumRequiredTags
+    }}
+  />
+</template>;
+
+export default FilteredTagsChooser;

--- a/assets/stylesheets/common/global-filter.scss
+++ b/assets/stylesheets/common/global-filter.scss
@@ -23,7 +23,9 @@ ol.category-breadcrumb > li:nth-child(-n + 2) {
   display: none;
 }
 
-.composer-fields .title-and-category details.mini-tag-chooser:first-of-type {
+.composer-fields
+  .title-and-category
+  .tags-input:not(.filtered-tags-composer-chooser) {
   // hide default composer tag chooser
   display: none;
 }


### PR DESCRIPTION
# Preview 

<img width="687" alt="Screenshot 2024-08-23 at 12 27 36 PM" src="https://github.com/user-attachments/assets/2870c3c6-b689-4876-96e4-a5c2adea73d9">


# Context 
This filtered tag chooser was accidentally removed in https://github.com/discourse/discourse-global-filter/pull/153. This PR adds it back.