### PR TITLE
FIX: Solve scrolling issue in categories

### DIFF
--- a/assets/javascripts/discourse/initializers/global-filter-preference.js
+++ b/assets/javascripts/discourse/initializers/global-filter-preference.js
@@ -178,7 +178,10 @@ export default {
         } else {
           const categoryURL = categorySlug ? `s/c/${categorySlug}` : "";
           url = `/tag${categoryURL}/${filterPref}`;
-          router.transitionTo(url, null, { queryParams });
+          transition.abort();
+          next(() => {
+            router.transitionTo(url, null, { queryParams });
+          });
         }
       }
     });

--- a/spec/system/global_filter_routing_spec.rb
+++ b/spec/system/global_filter_routing_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe "global filter routing", type: :system do
+  fab!(:support_tag) { Fabricate(:tag, name: "support") }
+  fab!(:feature_tag) { Fabricate(:tag, name: "feature") }
+
+  fab!(:topic) { Fabricate(:topic, tags: [support_tag]) }
+
+  fab!(:first_post) { Fabricate(:post, topic: topic) }
+  fab!(:second_post) { Fabricate(:post, topic: topic, post_number: 2) }
+  fab!(:third_post) { Fabricate(:post, topic: topic, post_number: 3) }
+  fab!(:fourth_post) { Fabricate(:post, topic: topic, post_number: 4) }
+  fab!(:fifth_post) { Fabricate(:post, topic: topic, post_number: 5) }
+
+  before do
+    SiteSetting.discourse_global_filter_enabled = true
+    SiteSetting.global_filters = "feature|support"
+    sign_in(Fabricate(:admin))
+  end
+
+  # Same test as https://github.com/discourse/discourse-global-filter/pull/125 but now in ruby
+  it "uses stored global filter preference at /" do
+    SiteSetting.top_menu = "categories|latest|new"
+    expect(SiteSetting.homepage).to eq("categories")
+
+    visit("/categories?tag=feature")
+
+    expect(page).to have_current_path("/categories?tag=feature")
+
+    visit("/")
+
+    expect(page).to have_current_path("/categories?tag=feature")
+
+    expect(page).to have_css("body.global-filter-tag-feature")
+  end
+end

--- a/spec/system/scrolls_correctly_in_categories_spec.rb
+++ b/spec/system/scrolls_correctly_in_categories_spec.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
-describe "scrolls correctly in categories", type: :system do
-  fab!(:support_tag) { Fabricate(:tag, name: "support") }
-  fab!(:feature_tag) { Fabricate(:tag, name: "feature") }
+describe "scrolls correctly in categories", type: :system, requires: [:scroll], focus_: true do
   let(:topic_list) { PageObjects::Components::TopicList.new }
 
+  fab!(:support_tag) { Fabricate(:tag, name: "support") }
+  fab!(:feature_tag) { Fabricate(:tag, name: "feature") }
+
+  fab!(:topic) { Fabricate(:topic, tags: [support_tag]) }
+
+  fab!(:first_post) { Fabricate(:post, topic: topic) }
+  fab!(:second_post) { Fabricate(:post, topic: topic, post_number: 2) }
+  fab!(:third_post) { Fabricate(:post, topic: topic, post_number: 3) }
+  fab!(:fourth_post) { Fabricate(:post, topic: topic, post_number: 4) }
+  fab!(:fifth_post) { Fabricate(:post, topic: topic, post_number: 5) }
+
   before do
-    Fabricate.times(21, :topic, tags: [support_tag])
-    Topic.all.each { |t| t.posts << Fabricate(:post, topic: t) }
     SiteSetting.discourse_global_filter_enabled = true
     SiteSetting.global_filters = "support|feature"
     sign_in(Fabricate(:admin))
@@ -20,12 +27,18 @@ describe "scrolls correctly in categories", type: :system do
   it "scrolls correctly when navigating from categories to topic lists, and remembers scroll position when going back" do
     visit "/"
 
-    page.scroll_to(0, 1000)
+    expect(topic_list).to have_topics
     topic_list_scroll_y = current_scroll_y
-    try_until_success { expect(topic_list_scroll_y).to be > 0 }
 
+    try_until_success { expect(topic_list_scroll_y).to eq(0) }
+
+    sleep 1
     topic_list.visit_topic(Topic.first)
-    try_until_success { expect(current_scroll_y).to eq(0) }
+
+    try_until_success do
+      page.scroll_to(find(".powered-by-discourse"))
+      expect(current_scroll_y).to be > 0
+    end
 
     page.go_back
     try_until_success { expect(current_scroll_y).to eq(topic_list_scroll_y) }

--- a/spec/system/scrolls_correctly_in_categories_spec.rb
+++ b/spec/system/scrolls_correctly_in_categories_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe "scrolls correctly in categories", type: :system do
+  fab!(:support_tag) { Fabricate(:tag, name: "support") }
+  fab!(:feature_tag) { Fabricate(:tag, name: "feature") }
+  before do
+    Fabricate.times(21, :topic, tags: [support_tag])
+    Fabricate.times(50, :post, topic: Topic.first)
+    SiteSetting.discourse_global_filter_enabled = true
+    SiteSetting.global_filters = "support|feature"
+    sign_in(Fabricate(:admin))
+  end
+
+  def current_scroll_y
+    page.evaluate_script("window.scrollY")
+  end
+
+  it "scrolls correctly when navigating from categories to topic lists, and remembers scroll position when going back" do
+    visit "/"
+
+    expect(page).to have_css(".topic-list-item")
+    page.execute_script <<~JS
+      document.querySelectorAll('.topic-list-item')[20].scrollIntoView(true);
+    JS
+
+    topic_list_scroll_y = current_scroll_y
+    try_until_success { expect(topic_list_scroll_y).to be > 0 }
+
+    find(".link-top-line", text: Topic.first.title).click
+    try_until_success { expect(current_scroll_y).to eq(0) }
+
+    page.go_back
+    try_until_success { expect(current_scroll_y).to eq(topic_list_scroll_y) }
+
+    find("#site-logo").click
+    try_until_success { expect(current_scroll_y).to eq(0) }
+  end
+end

--- a/spec/system/scrolls_correctly_in_categories_spec.rb
+++ b/spec/system/scrolls_correctly_in_categories_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "scrolls correctly in categories", type: :system, requires: [:scroll], focus_: true do
+describe "scrolls correctly in categories", type: :system do
   let(:topic_list) { PageObjects::Components::TopicList.new }
 
   fab!(:support_tag) { Fabricate(:tag, name: "support") }

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -1,4 +1,4 @@
-import { click, currentURL, settled, visit } from "@ember/test-helpers";
+import { currentURL, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { setDefaultHomepage } from "discourse/lib/utilities";
 import {
@@ -63,63 +63,9 @@ acceptance(
         });
       };
 
-      const responseHandlerWithTopics = () => {
-        return helper.response({
-          users: [],
-          primary_groups: [],
-          topic_list: {
-            can_create_topic: true,
-            draft: null,
-            draft_key: "new_topic",
-            draft_sequence: 1,
-            per_page: 30,
-            tags: [],
-            topics: [
-              {
-                id: 42,
-                title: "Hello world",
-                fancy_title: "Hello world",
-                slug: "hello-world",
-                posts_count: 1,
-                reply_count: 1,
-                highest_post_number: 1,
-                created_at: "2020-01-01T00:00:00.000Z",
-                last_posted_at: "2020-01-01T00:00:00.000Z",
-                bumped: true,
-                bumped_at: "2020-01-01T00:00:00.000Z",
-                archetype: "regular",
-                unseen: false,
-                last_read_post_number: 1,
-                unread_posts: 1,
-                pinned: false,
-                unpinned: null,
-                visible: true,
-                closed: true,
-                archived: false,
-                notification_level: 3,
-                bookmarked: false,
-                liked: true,
-                tags: ["test"],
-                tags_descriptions: { test: "test description" },
-                views: 42,
-                like_count: 42,
-                has_summary: false,
-                last_poster_username: "foo",
-                pinned_globally: false,
-                featured_link: null,
-                posters: [],
-              },
-            ],
-          },
-        });
-      };
-
       const successResponseHandler = () => helper.response({ success: true });
 
-      server.get(
-        "/tags/intersection/support/blog.json",
-        responseHandlerWithTopics
-      );
+      server.get("/tags/intersection/support/blog.json", emptyResponseHandler);
       server.get("/tag/support/l/top.json", emptyResponseHandler);
       server.get("/tag/support/l/latest.json", emptyResponseHandler);
       server.get("/tag/blog/l/latest.json", emptyResponseHandler);
@@ -136,8 +82,6 @@ acceptance(
         "/global_filter/filter_tags/categories_for_current_filter.json",
         successResponseHandler
       );
-
-      server.get("/t/42/1.json", successResponseHandler);
     });
 
     test("redirects to categories if it is default homepage when selected", async function (assert) {

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -1,4 +1,4 @@
-import { currentURL, visit } from "@ember/test-helpers";
+import { click, currentURL, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { setDefaultHomepage } from "discourse/lib/utilities";
 import {
@@ -205,6 +205,36 @@ acceptance(
       assert.ok(
         document.body.classList.contains("global-filter-tag-feature"),
         "it shows the global filter preference app"
+      );
+    });
+
+    test("scrolls correctly when navigating from categories to topic lists", async function (assert) {
+      await visit("/");
+
+      const topLocation = [0, 0];
+      // This line comes from:
+      // https://github.com/discourse/discourse/blob/766e0f7b364c09e383528e3771746aabebaa1d30/app/assets/javascripts/discourse/app/services/route-scroll-manager.js#L6-L7
+      const STORE_KEY = Symbol("scroll-location");
+      const historyStore = this.owner.lookup("service:history-store");
+      window.scroll({
+        top: 1000,
+        left: 0,
+      });
+
+      // click on the first category
+      await click(".category-title-link");
+      let scrollLocation = historyStore.get(STORE_KEY);
+      assert.equal(
+        scrollLocation,
+        topLocation,
+        "scrolls to the top of the page"
+      );
+      history.back();
+      scrollLocation = historyStore.get(STORE_KEY);
+      assert.equal(
+        scrollLocation,
+        [0, 1000],
+        "scrolls back to last location in the page"
       );
     });
   }

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -183,29 +183,5 @@ acceptance(
         "it redirects to the global filter if the new-topic tags query param is a child of one"
       );
     });
-
-    test("uses stored global filter preference at /", async function (assert) {
-      setDefaultHomepage("categories");
-      await visit("/categories?tag=feature");
-
-      assert.equal(
-        currentURL(),
-        "/categories?tag=feature",
-        "it navigates to the global filter"
-      );
-
-      await visit("/");
-
-      assert.equal(
-        currentURL(),
-        "/categories?tag=feature",
-        "it navigates to the stored global filter preference"
-      );
-
-      assert.ok(
-        document.body.classList.contains("global-filter-tag-feature"),
-        "it shows the global filter preference app"
-      );
-    });
   }
 );

--- a/test/javascripts/acceptance/global-filter-preference-test.js
+++ b/test/javascripts/acceptance/global-filter-preference-test.js
@@ -263,30 +263,5 @@ acceptance(
         "it shows the global filter preference app"
       );
     });
-
-    test("scrolls correctly when navigating from categories to topic lists", async function (assert) {
-      const toPosition = 100000;
-      const container = document.querySelector("#ember-testing-container");
-      await visit("/tag/blog");
-
-      container.scrollTop = toPosition;
-      await settled();
-      await click(".raw-topic-link");
-
-      assert.deepEqual(
-        container.scrollTop,
-        0,
-        "scrolls to the top of the page"
-      );
-
-      let router = this.owner.lookup("service:router");
-      router.transitionTo("tag.show", "blog");
-
-      assert.notEqual(
-        container.scrollTop,
-        0,
-        "scrolls back to last location in the page"
-      );
-    });
   }
 );


### PR DESCRIPTION
For some reason, the `transitionTo` would make the `scrollManager` bug out and not scroll to the top of the page.

This PR solves that and adds a test to ensure we do not have regressions