### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/admin/filter-children-form.gjs
+++ b/assets/javascripts/discourse/components/admin/filter-children-form.gjs
@@ -48,7 +48,7 @@ const FilterChildrenForm = <template>
       <DButton
         @ariaLabel="global_filter.admin.cancel_create_filter_child"
         @action={{@cancelSetFilterChildrenForFilter}}
-        @icon="times"
+        @icon="xmark"
       />
     </div>
   {{else}}

--- a/assets/javascripts/discourse/components/admin/filter-children-table.gjs
+++ b/assets/javascripts/discourse/components/admin/filter-children-table.gjs
@@ -42,7 +42,7 @@ const FilterChildrenTable = <template>
             <DButton
               @ariaLabel="global_filter.admin.edit_filter_child"
               @action={{fn @editFilterChildForFilter @filterTag.name values}}
-              @icon="pencil-alt"
+              @icon="pencil"
             />
             <DButton
               @ariaLabel="global_filter.admin.delete_filter_child"
@@ -51,7 +51,7 @@ const FilterChildrenTable = <template>
                 @filterTag.name
                 values.name
               }}
-              @icon="far-trash-alt"
+              @icon="far-trash-can"
             />
           </td>
         </tr>


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.